### PR TITLE
[Feature] Added Support for Over-riding Destination SDK Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 2. Rudder-Braze is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Rudder-Braze', '1.0.3'
+pod 'Rudder-Braze', '1.0.4'
 ```
 
 ## Initialize ```RSClient```

--- a/Rudder-Braze.podspec
+++ b/Rudder-Braze.podspec
@@ -1,3 +1,6 @@
+
+appboy_sdk_version = '4.4.2'
+
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Braze'
   s.version          = '1.0.3'
@@ -22,5 +25,13 @@ Rudder is a platform for collecting, storing and routing customer event data to 
   s.source_files = 'Rudder-Braze/Classes/**/*'
 
   s.dependency 'Rudder', '~> 1.0'
-  s.dependency 'Appboy-iOS-SDK', '4.4.2'
+
+  if defined?($AppboySDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Appboy SDK version '#{$AppboySDKVersion}'"
+    appboy_sdk_version = $AppboySDKVersion
+  else
+    Pod::UI.puts "#{s.name}: Using default Appboy SDK version '#{appboy_sdk_version}'"
+  end
+
+  s.dependency 'Appboy-iOS-SDK', appboy_sdk_version
 end

--- a/Rudder-Braze.podspec
+++ b/Rudder-Braze.podspec
@@ -3,7 +3,7 @@ appboy_sdk_version = '4.4.2'
 
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Braze'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'Privacy and Security focused Segment-alternative. Braze Native SDK integration support.'
 
   s.description      = <<-DESC
@@ -13,7 +13,7 @@ Rudder is a platform for collecting, storing and routing customer event data to 
   s.homepage         = 'https://github.com/rudderlabs/rudder-integration-braze-ios'
   s.license          = { :type => "Apache", :file => "LICENSE" }
   s.author           = { 'RudderStack' => 'raj@rudderlabs.com' }
-  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-braze-ios.git', :tag => 'v1.0.3' }
+  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-braze-ios.git', :tag => 'v1.0.4' }
   s.platform         = :ios, "9.0"
 
   ## Ref: https://github.com/CocoaPods/CocoaPods/issues/10065


### PR DESCRIPTION
## Description of the change

Added Support for Over-riding Destination SDK Version with the Version User wants to resolve the conflicts between other Libraries.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
