### PR TITLE
feat: provide getBrazeInstance API support to return Braze instance

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,4 +6,16 @@ platform :ios, '11.0'
 
 target 'Rudder-Braze_Example' do
   pod 'Rudder-Braze', :path => '../'
+  pod 'BrazeUI' # Used to enable Braze IAM (In App Messaging)
+  
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        xcconfig_path = config.base_configuration_reference.real_path
+        xcconfig = File.read(xcconfig_path)
+        xcconfig_mod = xcconfig.gsub(/DT_TOOLCHAIN_DIR/, "TOOLCHAIN_DIR")
+        File.open(xcconfig_path, "w") { |file| file << xcconfig_mod }
+      end
+    end
+  end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,20 @@
 PODS:
-  - BrazeKit (6.6.0)
+  - BrazeKit (6.6.1)
+  - BrazeUI (6.6.1):
+    - BrazeKit (= 6.6.1)
   - Rudder (1.17.0)
-  - Rudder-Braze (1.2.0):
+  - Rudder-Braze (1.3.0):
     - BrazeKit (~> 6.6.0)
     - Rudder (~> 1.12)
 
 DEPENDENCIES:
+  - BrazeUI
   - Rudder-Braze (from `../`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - BrazeKit
+    - BrazeUI
     - Rudder
 
 EXTERNAL SOURCES:
@@ -18,10 +22,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: 3c25fd2317ef39059c7305074c3662971f6373cc
+  BrazeKit: 7199d564cd3c90842b11a12ff11b99d0dbbb2579
+  BrazeUI: 6f85e1861f96623e520a3af91d2eaf82faf6118c
   Rudder: 3f4ab09638452282a22b96a388b54132dcd3fca8
-  Rudder-Braze: 62c398e51ab4e66d00cf69c95e59d58cdb4aad34
+  Rudder-Braze: a1b41927b91b067f242c5576f6157e0cea9e59a2
 
-PODFILE CHECKSUM: 3a55374ddc967c0c098f9b411fb2311d95064e0c
+PODFILE CHECKSUM: 3612ddeb3ca2409c50b61623c21d9adc0f7d19c2
 
 COCOAPODS: 1.11.3

--- a/Example/Rudder-Braze.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Braze.xcodeproj/project.pbxproj
@@ -405,10 +405,12 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Rudder-Braze_Example/Pods-Rudder-Braze_Example-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/BrazeKit/BrazeKit.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/BrazeUI/BrazeUI.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/BrazeKit.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/BrazeUI.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/Rudder-Braze/RUDDERAppDelegate.m
+++ b/Example/Rudder-Braze/RUDDERAppDelegate.m
@@ -12,12 +12,26 @@
 #import "Rudder_Braze_Example-Swift.h"
 #import "RudderBrazeIntegration.h"
 #import <UserNotifications/UserNotifications.h>
+@import BrazeUI;
 
 @implementation RUDDERAppDelegate
+
+static Braze *braze;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
+    
+    // Setup In App Messaging
+    [RudderBrazeIntegration getBrazeInstance:^(Braze * _Nullable brazeInstance) {
+        if (brazeInstance != nil) {
+            braze = brazeInstance;
+            [self configureIAM];
+        } else {
+            NSLog(@"Error getting Braze instance.");
+        }
+    }];
+
     
     /// Copy the `SampleRudderConfig.plist` and rename it to`RudderConfig.plist` on the same directory.
     /// Update the values as per your need.
@@ -39,6 +53,14 @@
         }
     }
     return YES;
+}
+
+-(void) configureIAM {
+    // Set up IAM (In App Messaging)
+    BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
+    braze.inAppMessagePresenter = inAppMessageUI;
+    [braze changeUser:@"2d31d085-4d93-4126-b2b3-94e651810673"];
+    [[RSClient getInstance] identify:@"2d31d085-4d93-4126-b2b3-94e651810673"];
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application

--- a/Example/Rudder-Braze/RUDDERAppDelegate.m
+++ b/Example/Rudder-Braze/RUDDERAppDelegate.m
@@ -56,9 +56,10 @@ static Braze *braze;
 }
 
 -(void) configureIAM {
-    // Set up IAM (In App Messaging)
+    // Set up Braze IAM (In App Messaging)
     BrazeInAppMessageUI *inAppMessageUI = [[BrazeInAppMessageUI alloc] init];
     braze.inAppMessagePresenter = inAppMessageUI;
+    // This explicit identify call to Braze is necessary to make configure the IAM.
     [braze changeUser:@"2d31d085-4d93-4126-b2b3-94e651810673"];
     [[RSClient getInstance] identify:@"2d31d085-4d93-4126-b2b3-94e651810673"];
 }

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -29,7 +29,6 @@ typedef enum {
 
 @interface RudderBrazeIntegration : NSObject<RSIntegration> {
     ConnectionMode connectionMode;
-    Braze *braze;
 }
 
 @property (nonatomic, strong) NSDictionary *config;
@@ -38,6 +37,8 @@ typedef enum {
 @property (nonatomic, strong) RSMessage *previousIdentifyElement;
 
 - (instancetype)initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client rudderConfig:(nonnull RSConfig *)rudderConfig ;
++ (void)getBrazeInstance:(void (^)(Braze *brazeInstance))completion;
+
 
 -(void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 // Following the guidance provided in the Braze documentation at https://www.braze.com/docs/developer_guide/platform_integration_guides/swift/push_notifications/integration/#step-3-enable-push-handling, it is recommended to invoke the push integration code within the main thread of the application.


### PR DESCRIPTION
# Description

- Added `getBrazeInstance` which returns the Braze instance.
- This API has callback support, which will return the instance, instantly, if the instance is present, else will wait for the Braze SDK to get initialised.
- This API could be used to configure Braze IAM (In-App Messaging): Setup has been provided in the sample app of this project.