### PR TITLE
feat: bump the `braze_kit` sdk version to 9.3.0

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -13,11 +13,12 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v3
         
+      # I observed that the `Execute pod lint` step is failing and the setting up the XCode to 15.4 seems to solve the issue.
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.4'
-          
+
       - name: Install Cocoapods
         run: gem install cocoapods
       

--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v3
         
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.4'
+          
       - name: Install Cocoapods
         run: gem install cocoapods
       

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
     - name: Checkout source branch
       uses: actions/checkout@v3
+
+    # Added the XCode setup step to avoid the `pod lib lint` step from failing.
+    - name: Set up Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.4'
     
     - name: Install Cocoapods
       run: gem install cocoapods

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -86,4 +86,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: 'pallabmaiti'
+          pr_reviewer: '@rudderlabs/sdk-ios'

--- a/.github/workflows/manage-github-issue-for-outdated-pods.yml
+++ b/.github/workflows/manage-github-issue-for-outdated-pods.yml
@@ -19,7 +19,7 @@ jobs:
           outdated-pod-names: "BrazeKit"
           directory: "Example"
           title: "fix: update Braze SDK to the latest version"
-          assignee: "desusai7"
+          assignee: "@rudderlabs/sdk-ios"
           labels: "outdatedPod"
           color: "FBCA04"
         env:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @rudderlabs/sdk-ios

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - BrazeKit (7.5.0)
-  - BrazeUI (7.5.0):
-    - BrazeKit (= 7.5.0)
+  - BrazeKit (9.3.0)
+  - BrazeUI (9.3.0):
+    - BrazeKit (= 9.3.0)
   - MetricsReporter (1.2.1):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.25.1):
+  - Rudder (1.26.3):
     - MetricsReporter (= 1.2.1)
-  - Rudder-Braze (1.4.0):
-    - BrazeKit (~> 7.5.0)
-    - Rudder (~> 1.24)
+  - Rudder-Braze (2.0.0):
+    - BrazeKit (~> 9.3.0)
+    - Rudder (~> 1.26)
   - RudderKit (1.4.0)
 
 DEPENDENCIES:
@@ -31,12 +31,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: 55dfadd08105765a568137f5d24d46894186db65
-  BrazeUI: 3ed7ee01971c3e7a14ba7b6f1e3b1a32a89f1199
+  BrazeKit: 149a9b3386d14b67f6f7a0010053282021f93518
+  BrazeUI: f25797cc6e40d02bbe7d5c6bd1c0c532b6d26ff4
   MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 34799a1be015f03d7073a919c4b3557cfde428d4
-  Rudder-Braze: 8d604b6ac015243cb7e01d3a8c700ce6ea64e909
+  Rudder: 23456f79749849870e18c45bd250d6e2229a7147
+  Rudder-Braze: 31b8c23bdadecdbd09c07d02bdac495d483a564f
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: d5cb3999cad3c9449f37674bd32ddede28c1f721

--- a/Rudder-Braze.podspec
+++ b/Rudder-Braze.podspec
@@ -2,8 +2,8 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-braze_kit = '~> 7.5.0'
-rudder_sdk_version = '~> 1.24'
+braze_kit = '~> 9.3.0'
+rudder_sdk_version = '~> 1.26'
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Braze'
   s.version          = package['version']


### PR DESCRIPTION
# Description

- Bumped the Braze SDK version to `9.3.0` (it's the latest version, as of now).
- Bumped the Rudder SDK version to `1.26`.
- Update Codeowners across GitHub actions.
- I observed that GitHub Action for checking the build is failing due to an unknown reason; interestingly the same command (`pod lib lint --no-clean --allow-warnings`) is passing locally. After careful observation, I came to the conclusion that it might be related to the XCode version. So, I added a step to set the XCode version to `15.4` which solved the build issue in GitHub Action. I also added the same step in the `deploy-cocoapod` GitHub Action, as that could also fail (this was a safety procedure).