### PR TITLE
fix!: correct the setting of externalId and userId

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - BrazeKit (9.3.0)
-  - BrazeUI (9.3.0):
-    - BrazeKit (= 9.3.0)
-  - MetricsReporter (1.2.1):
+  - BrazeKit (9.3.1)
+  - BrazeUI (9.3.1):
+    - BrazeKit (= 9.3.1)
+  - MetricsReporter (2.0.0):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.26.3):
-    - MetricsReporter (= 1.2.1)
-  - Rudder-Braze (2.0.0):
+  - Rudder (1.31.0):
+    - MetricsReporter (= 2.0.0)
+  - Rudder-Braze (2.2.0):
     - BrazeKit (~> 9.3.0)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
@@ -31,14 +31,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: 149a9b3386d14b67f6f7a0010053282021f93518
-  BrazeUI: f25797cc6e40d02bbe7d5c6bd1c0c532b6d26ff4
-  MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
+  BrazeKit: 4da9eda353092104add9d3fcbb272afbd14dd3de
+  BrazeUI: b14b2aedb74154185dd9c5b951fdd37ed30d59c3
+  MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 23456f79749849870e18c45bd250d6e2229a7147
-  Rudder-Braze: 31b8c23bdadecdbd09c07d02bdac495d483a564f
+  Rudder: 04713668b0b7d46f214e6b7b46b60134849661aa
+  Rudder-Braze: 787726b97909bd097323258f7f94d2a45ac4538c
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: d5cb3999cad3c9449f37674bd32ddede28c1f721
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/Example/Rudder-Braze/RUDDERAppDelegate.m
+++ b/Example/Rudder-Braze/RUDDERAppDelegate.m
@@ -7,12 +7,12 @@
 //
 
 #import "RUDDERAppDelegate.h"
+#import <Rudder/Rudder.h>
 #import "RudderBrazeFactory.h"
 #import "Rudder_Braze_Example-Swift.h"
 #import "RudderBrazeIntegration.h"
 #import <UserNotifications/UserNotifications.h>
 @import BrazeUI;
-@import Rudder;
 
 @implementation RUDDERAppDelegate
 

--- a/Example/Rudder-Braze/RUDDERViewController.m
+++ b/Example/Rudder-Braze/RUDDERViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "RUDDERViewController.h"
-@import Rudder;
+#import <Rudder/Rudder.h>
 
 @interface RUDDERViewController ()
 

--- a/Rudder-Braze/Classes/RudderBrazeFactory.h
+++ b/Rudder-Braze/Classes/RudderBrazeFactory.h
@@ -6,7 +6,11 @@
 
 #import <Foundation/Foundation.h>
 #import "RudderBrazeIntegration.h"
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Braze/Classes/RudderBrazeFactory.h
+++ b/Rudder-Braze/Classes/RudderBrazeFactory.h
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 #import "RudderBrazeIntegration.h"
-@import Rudder;
+#import <Rudder/Rudder.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -7,7 +7,11 @@
 #import <Foundation/Foundation.h>
 
 @import BrazeKit;
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
 #import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
  
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -35,6 +35,7 @@ typedef enum {
 @property (nonatomic, strong) RSClient *client;
 @property (nonatomic) BOOL supportDedup;
 @property (nonatomic, strong) RSMessage *previousIdentifyElement;
+@property (nonatomic) NSString *prevExternalId;
 
 - (instancetype)initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client rudderConfig:(nonnull RSConfig *)rudderConfig ;
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -7,7 +7,7 @@
 #import <Foundation/Foundation.h>
 
 @import BrazeKit;
-@import Rudder;
+#import <Rudder/Rudder.h>
  
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -78,7 +78,7 @@ static Braze *rsBrazeInstance;
                 break;
         }
 
-        rsBrazeInstance = [[Braze alloc] initWithConfiguration:configuration];
+       rsBrazeInstance = [[Braze alloc] initWithConfiguration:configuration];
     }
     return self;
 }
@@ -121,14 +121,13 @@ static Braze *rsBrazeInstance;
         }
         
         // look for externalIds first
-        NSString *prevExternalId = [self getExternalId:self.previousIdentifyElement];
         NSString *currExternalId = [self getExternalId:message];
         
         NSString *prevUserId = self.previousIdentifyElement.userId;
         NSString *currUserId = message.userId;
 
         if (currExternalId) {
-            if (prevExternalId == nil || ![currExternalId isEqualToString:prevExternalId]) {
+            if (self.prevExternalId == nil || ![currExternalId isEqualToString:self.prevExternalId]) {
                 [rsBrazeInstance changeUser:currExternalId];
                 [RSLogger logInfo:@"Identify: Braze changeUser with externalId"];
             }
@@ -138,6 +137,8 @@ static Braze *rsBrazeInstance;
                 [RSLogger logInfo:@"Identify: Braze changeUser with userId"];
             }
         }
+        // As we are unable to make a deep copy of the externalId in the self.previousIdentifyElement, we need the following workaround:
+        self.prevExternalId = currExternalId;
         
         if ([message.context.traits[@"email"] isKindOfClass:[NSString class]]) {
             NSString *email = [self needUpdate:@"email" withMessage:message];

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -126,13 +126,17 @@ static Braze *rsBrazeInstance;
         
         NSString *prevUserId = self.previousIdentifyElement.userId;
         NSString *currUserId = message.userId;
-        
-        if ((prevExternalId == nil && currExternalId != nil) || (![currExternalId isEqual:prevExternalId])) {
-            [rsBrazeInstance changeUser:currExternalId];
-            [RSLogger logInfo:@"Identify: Braze changeUser with externalId"];
-        } else if ((prevUserId == nil && currUserId != nil) || (![currUserId isEqual:prevUserId])) {
-            [rsBrazeInstance changeUser:currUserId];
-            [RSLogger logInfo:@"Identify: Braze changeUser with userId"];
+
+        if (currExternalId) {
+            if (prevExternalId == nil || ![currExternalId isEqualToString:prevExternalId]) {
+                [rsBrazeInstance changeUser:currExternalId];
+                [RSLogger logInfo:@"Identify: Braze changeUser with externalId"];
+            }
+        } else if (currUserId) {
+            if (prevUserId == nil || ![currUserId isEqualToString:prevUserId]) {
+                [rsBrazeInstance changeUser:currUserId];
+                [RSLogger logInfo:@"Identify: Braze changeUser with userId"];
+            }
         }
         
         if ([message.context.traits[@"email"] isKindOfClass:[NSString class]]) {

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -78,7 +78,7 @@ static Braze *rsBrazeInstance;
                 break;
         }
 
-       rsBrazeInstance = [[Braze alloc] initWithConfiguration:configuration];
+        rsBrazeInstance = [[Braze alloc] initWithConfiguration:configuration];
     }
     return self;
 }


### PR DESCRIPTION
# Description

- Here's how we give the preference: `externalId` vs. `userId`
    - If current `externalId` is not nil, and either `previousExternalId` is nil or, if present, it is not equal to the current externalId, then set the current externalId.
    - If current externalId is nil then repeat the above process for the userId.
- Fixed the issue where we were setting `nil`, if externalId is nil.
- Fixed the issue where, if in the same app run, more than one identify event is made with the same userId but with different externalId, then we need to set the new externalId to Braze. Previously, in this case, only the first externalId was being set.
    - This issue was occurring because we are not creating a deep copy of the message object, specifically the `externalId`. Now, as a workaround, we're directly caching the `brazeExternalId` value; instead of relying on the cached message object. 
    - We tested the userId and other traits value and they are being set properly.
- ~~Fixed duplication symbol issue. We reverted the import header changes that we did in the last PR.~~ In Factory classes, we have to change the import from `#import <Rudder/Rudder.h>` to the following code: This is required to address the build failure when this package is integrated using SPM. In case, if we don't add this then there will be build failure.
```
#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
#import <Rudder/Rudder.h>
#else
#import "Rudder.h"
#endif
```

# Breaking change

- Previously, if in the same app run, more than one identify event is made with the same userId but with different externalId, then only the first externalId was being set.
- Now, in such scenarios, we are setting the updated (or changed) externalId.