### PR TITLE
ci: use shas for external github actions

### DIFF
--- a/.github/workflows/build-and-quality-checks.yml
+++ b/.github/workflows/build-and-quality-checks.yml
@@ -12,12 +12,6 @@ jobs:
     steps:
       - name: Checkout source branch
         uses: actions/checkout@v3
-        
-      # I observed that the `Execute pod lint` step is failing and the setting up the XCode to 15.4 seems to solve the issue.
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '15.4'
 
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
     - name: Checkout source branch
       uses: actions/checkout@v3
-
-    # Added the XCode setup step to avoid the `pod lib lint` step from failing.
-    - name: Set up Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '15.4'
     
     - name: Install Cocoapods
       run: gem install cocoapods

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -79,7 +79,7 @@ jobs:
           git push --follow-tags
 
       - name: Create pull request into master
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync Github PRs to Notion
-        uses: sivashanmukh/github-notion-pr-sync@1.0.0
+        uses: sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}


### PR DESCRIPTION
# Description

- Using SHA's for these two actions:
```
repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

sivashanmukh/github-notion-pr-sync@3967330238449a8550b06f6e1d6b83e1af569876 #v1.0.0
```
- Removed `Set up Xcode` steps. I think it's not required and also it'll block our release process. Will see how the release goes without it.