### PR TITLE
feat: add australia and united states regions support in braze sdk

### DIFF
--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -43,12 +43,16 @@ static Braze *rsBrazeInstance;
                 brazeEndPoint = @"sdk.iad-05.braze.com";
             } else if([@"US-06" isEqualToString:customEndpoint]) {
                 brazeEndPoint = @"sdk.iad-06.braze.com";
+            } else if([@"US-07" isEqualToString:customEndpoint]) {
+                brazeEndPoint = @"sdk.iad-07.braze.com";
             } else if([@"US-08" isEqualToString:customEndpoint]) {
                 brazeEndPoint = @"sdk.iad-08.braze.com";
             } else if([@"EU-01" isEqualToString:customEndpoint]) {
                 brazeEndPoint = @"sdk.fra-01.braze.eu";
             } else if([@"EU-02" isEqualToString:customEndpoint]) {
                 brazeEndPoint = @"sdk.fra-02.braze.eu";
+            } else if([@"AU-01" isEqualToString:customEndpoint]) {
+                brazeEndPoint = @"sdk.au-01.braze.com";
             }
         }
         


### PR DESCRIPTION
# Description

This PR adds missing regions - `US-07` and `AU-01` to the braze list of supported regions for data centers.
