### PR TITLE
feat(braze): add support for platform-specific app keys

### DIFF
--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,7 +19,7 @@ static Braze *rsBrazeInstance;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
 
-        // Check if platform-specific key should be used
+        // Prefer platform-specific key if present
         BOOL usePlatformSpecificKeys = [[config objectForKey:@"usePlatformSpecificKeys"] boolValue];
         NSString *iOSAppKey = [config objectForKey:@"iOSAppKey"];
         NSString *apiToken = (usePlatformSpecificKeys && iOSAppKey) ? iOSAppKey : [config objectForKey:@"appKey"];

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -22,11 +22,14 @@ static Braze *rsBrazeInstance;
         BOOL usePlatformSpecificApiKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
         NSString *apiKey = @"";
         // Prefer platform-specific key if present and not empty
-        if (usePlatformSpecificApiKeys && [config objectForKey:@"iOSAppKey"]) {
-            apiKey = [config objectForKey:@"iOSAppKey"];
+        if (usePlatformSpecificApiKeys && [config objectForKey:@"iOSApiKey"]) {
+            apiKey = [config objectForKey:@"iOSApiKey"];
         }
         // Fallback to default app key if either platform-specific key is not present or is set to false
         if ([apiKey length] == 0 && [config objectForKey:@"appKey"]) {
+            if (usePlatformSpecificApiKeys) {
+                [RSLogger logError:@"BrazeIntegration: usePlatformSpecificApiKeys is enabled but iOSApiKey is not configured. Falling back to legacy apiKey."];
+            }
             apiKey = [config objectForKey:@"appKey"];
         }
         connectionMode = [self getConnectionMode:config];

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,10 +19,16 @@ static Braze *rsBrazeInstance;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
 
-        // Prefer platform-specific key if present
         BOOL usePlatformSpecificKeys = [[config objectForKey:@"usePlatformSpecificKeys"] boolValue];
-        NSString *iOSAppKey = [config objectForKey:@"iOSAppKey"];
-        NSString *apiToken = (usePlatformSpecificKeys && iOSAppKey) ? iOSAppKey : [config objectForKey:@"appKey"];
+        NSString *apiToken = @"";
+        // Prefer platform-specific key if present and not empty
+        if (usePlatformSpecificKeys && [config objectForKey:@"iOSAppKey"]) {
+            apiToken = [config objectForKey:@"iOSAppKey"];
+        }
+        // Fallback to default app key if platform-specific key is not defined or is empty
+        if ([apiToken length] == 0 && [config objectForKey:@"appKey"]) {
+            apiToken = [config objectForKey:@"appKey"];
+        }
         connectionMode = [self getConnectionMode:config];
         
         if ( [apiToken length] == 0) {

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -18,7 +18,11 @@ static Braze *rsBrazeInstance;
         self.config = config;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
-        NSString *apiToken = [config objectForKey:@"appKey"];
+
+        // Check if platform-specific key should be used
+        BOOL usePlatformSpecificKeys = [[config objectForKey:@"usePlatformSpecificKeys"] boolValue];
+        NSString *iOSAppKey = [config objectForKey:@"iOSAppKey"];
+        NSString *apiToken = (usePlatformSpecificKeys && iOSAppKey) ? iOSAppKey : [config objectForKey:@"appKey"];
         connectionMode = [self getConnectionMode:config];
         
         if ( [apiToken length] == 0) {

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -66,7 +66,7 @@ static Braze *rsBrazeInstance;
             }
         }
         
-        BRZConfiguration *configuration = [[BRZConfiguration alloc] initWithApiKey:apiToken
+        BRZConfiguration *configuration = [[BRZConfiguration alloc] initWithApiKey:apiKey
                                                                           endpoint:brazeEndPoint];
         
         // For more details on Braze log level -> https://www.braze.com/docs/developer_guide/platform_integration_guides/swift/initial_sdk_setup/other_sdk_customizations/#braze-log-level

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,10 +19,10 @@ static Braze *rsBrazeInstance;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
 
-        BOOL usePlatformSpecificKeys = [[config objectForKey:@"usePlatformSpecificKeys"] boolValue];
+        BOOL usePlatformSpecificApiKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
         NSString *apiKey = @"";
         // Prefer platform-specific key if present and not empty
-        if (usePlatformSpecificKeys && [config objectForKey:@"iOSAppKey"]) {
+        if (usePlatformSpecificApiKeys && [config objectForKey:@"iOSAppKey"]) {
             apiKey = [config objectForKey:@"iOSAppKey"];
         }
         // Fallback to default app key if either platform-specific key is not present or is set to false

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -25,7 +25,7 @@ static Braze *rsBrazeInstance;
         if (usePlatformSpecificKeys && [config objectForKey:@"iOSAppKey"]) {
             apiKey = [config objectForKey:@"iOSAppKey"];
         }
-        // Fallback to default app key if platform-specific key is not defined or is empty
+        // Fallback to default app key if either platform-specific key is not present or is set to false
         if ([apiKey length] == 0 && [config objectForKey:@"appKey"]) {
             apiKey = [config objectForKey:@"appKey"];
         }

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -20,19 +20,19 @@ static Braze *rsBrazeInstance;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
 
         BOOL usePlatformSpecificKeys = [[config objectForKey:@"usePlatformSpecificKeys"] boolValue];
-        NSString *apiToken = @"";
+        NSString *apiKey = @"";
         // Prefer platform-specific key if present and not empty
         if (usePlatformSpecificKeys && [config objectForKey:@"iOSAppKey"]) {
-            apiToken = [config objectForKey:@"iOSAppKey"];
+            apiKey = [config objectForKey:@"iOSAppKey"];
         }
         // Fallback to default app key if platform-specific key is not defined or is empty
-        if ([apiToken length] == 0 && [config objectForKey:@"appKey"]) {
-            apiToken = [config objectForKey:@"appKey"];
+        if ([apiKey length] == 0 && [config objectForKey:@"appKey"]) {
+            apiKey = [config objectForKey:@"appKey"];
         }
         connectionMode = [self getConnectionMode:config];
-        
-        if ( [apiToken length] == 0) {
-            [RSLogger logError:@"API Token is invalid. Aborting Braze SDK initalisation."];
+
+        if ( [apiKey length] == 0) {
+            [RSLogger logError:@"API Key is invalid. Aborting Braze SDK initalisation."];
             return nil;
         }
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -21,16 +21,20 @@ static Braze *rsBrazeInstance;
 
         BOOL usePlatformSpecificApiKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
         NSString *apiKey = @"";
-        // Prefer platform-specific key if present and not empty
-        if (usePlatformSpecificApiKeys && [config objectForKey:@"iOSApiKey"]) {
-            apiKey = [config objectForKey:@"iOSApiKey"];
-        }
-        // Fallback to default app key if either platform-specific key is not present or is set to false
-        if ([apiKey length] == 0 && [config objectForKey:@"appKey"]) {
-            if (usePlatformSpecificApiKeys) {
-                [RSLogger logError:@"BrazeIntegration: Configured to use platform-specific API keys but Android API key is not valid. Falling back to the default API key."];
-            }
+        // Start with default API key
+        if ([config objectForKey:@"appKey"]) {
             apiKey = [config objectForKey:@"appKey"];
+        }
+
+        // Override with platform-specific key if configured
+        if (usePlatformSpecificApiKeys) {
+            NSString *iOSApiKey = [config objectForKey:@"iOSApiKey"] ?: @"";
+
+            if ([iOSApiKey length] > 0) {
+                apiKey = iOSApiKey;
+            } else {
+                [RSLogger logError:@"BrazeIntegration: Configured to use platform-specific API keys but iOS API key is not valid. Falling back to the default API key."];
+            }
         }
         connectionMode = [self getConnectionMode:config];
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -28,7 +28,7 @@ static Braze *rsBrazeInstance;
         // Fallback to default app key if either platform-specific key is not present or is set to false
         if ([apiKey length] == 0 && [config objectForKey:@"appKey"]) {
             if (usePlatformSpecificApiKeys) {
-                [RSLogger logError:@"BrazeIntegration: usePlatformSpecificApiKeys is enabled but iOSApiKey is not configured. Falling back to legacy apiKey."];
+                [RSLogger logError:@"BrazeIntegration: Configured to use platform-specific API keys but Android API key is not valid. Falling back to the default API key."];
             }
             apiKey = [config objectForKey:@"appKey"];
         }

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -31,7 +31,7 @@ static Braze *rsBrazeInstance;
         }
         connectionMode = [self getConnectionMode:config];
 
-        if ( [apiKey length] == 0) {
+        if ([apiKey length] == 0) {
             [RSLogger logError:@"API Key is invalid. Aborting Braze SDK initalisation."];
             return nil;
         }


### PR DESCRIPTION
## Description

This PR adds support for platform-specific app key configuration in the Braze iOS integration, enabling multi-platform app key management. When `usePlatformSpecificKeys` is enabled, the integration will prioritise the new `iOSAppKey` configuration field over the legacy `appKey` field. The implementation maintains full backward compatibility by falling back to the existing `appKey` when the feature is not enabled or platform-specific keys are not configured.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Approach

The implementation introduces two new configuration fields:
- `iOSAppKey`: Platform-specific app key for iOS
- `usePlatformSpecificKeys`: UI toggle to enable platform-specific key resolution

When the UI toggle is enabled and `iOSAppKey` is present, the integration will prioritise it over the legacy `appKey` field. If the feature is disabled or the platform-specific key is not configured, the integration falls back to the existing `appKey` field, ensuring full backward compatibility.

The legacy `appKey` field has been marked as deprecated with proper documentation to guide future migrations. (Note: This is an internal field used in the SDK).

### Impact

- **Backward Compatibility**: Fully maintained - existing configurations using `appKey` continue to work without changes
- **Breaking Changes**: None
- **New Dependencies**: None
- **Configuration Changes**: Two new optional fields in destination configuration