### PR TITLE
chore(release): pulling release/4.2.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 4.2.0 (2025-11-27)
+
+
+### Features
+
+* **braze:** add support for platform-specific app keys ([#67](https://github.com/rudderlabs/rudder-integration-braze-ios/issues/67)) ([005a53d](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/005a53d731f47d8511c48480d7f6a92a67f5b176))
+
 ## [4.1.0](https://github.com/rudderlabs/rudder-integration-braze-ios/compare/v4.0.0...v4.1.0) (2025-09-17)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 Add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-Braze', '4.1.0'
+pod 'Rudder-Braze', '4.2.0'
 ```
 
 ## Swift Package Manager (SPM)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "4.1.0",
+    "version": "4.2.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   4.1.0 (2025-11-27)<br> * feat(braze): add support for platform-specific app keys ( 67) ([005a53d](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/005a53d)), closes [ 67](https://github.com/rudderlabs/rudder-integration-braze-ios/issues/67)<br> * Merge pull request  62 from rudderlabs/chore/GHA-230316-stepsecurity-remediation ([423694b](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/423694b)), closes [ 62](https://github.com/rudderlabs/rudder-integration-braze-ios/issues/62)