### PR TITLE
chore(release): pulling release/4.2.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 4.2.1 (2026-01-02)
+
+
+### Bug Fixes
+
+* **braze:** rename API Key to App Identifier Key terminology ([19ccbdd](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/19ccbddac7edfb338ad8a4b1c50beed3d516a908))
+
 ## 4.2.0 (2025-11-27)
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 
 ## Integrating Braze with RudderStack's iOS SDK
 
-1. Add [Braze](https://www.braze.com) as a destination in the [Dashboard](https://app.rudderstack.com/) and define ```REST api key```, ```App Key``` and ```Data Center Instance```
+1. Add [Braze](https://www.braze.com) as a destination in the [Dashboard](https://app.rudderstack.com/) and define ```REST API key```, ```App Identifier Key``` and ```Data Center Instance```
 
 2. Rudder-Braze is available through [CocoaPods](https://cocoapods.org) and [Swift Package Manager (SPM)](https://www.swift.org/documentation/package-manager/).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More information on RudderStack can be found [here](https://github.com/rudderlab
 Add the following line to your Podfile and followed by `pod install`:
 
 ```ruby
-pod 'Rudder-Braze', '4.2.0'
+pod 'Rudder-Braze', '4.2.1'
 ```
 
 ## Swift Package Manager (SPM)

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,27 +19,27 @@ static Braze *rsBrazeInstance;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
 
-        BOOL usePlatformSpecificApiKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
-        NSString *apiKey = @"";
-        // Start with default API key
+        BOOL usePlatformSpecificAppIdentifierKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
+        NSString *appIdentifierKey = @"";
+        // Start with default App Identifier Key
         if ([config objectForKey:@"appKey"]) {
-            apiKey = [config objectForKey:@"appKey"];
+            appIdentifierKey = [config objectForKey:@"appKey"];
         }
 
         // Override with platform-specific key if configured
-        if (usePlatformSpecificApiKeys) {
-            NSString *iOSApiKey = [config objectForKey:@"iOSApiKey"] ?: @"";
+        if (usePlatformSpecificAppIdentifierKeys) {
+            NSString *iOSAppIdentifierKey = [config objectForKey:@"iOSApiKey"] ?: @"";
 
-            if ([iOSApiKey length] > 0) {
-                apiKey = iOSApiKey;
+            if ([iOSAppIdentifierKey length] > 0) {
+                appIdentifierKey = iOSAppIdentifierKey;
             } else {
-                [RSLogger logError:@"BrazeIntegration: Configured to use platform-specific API keys but iOS API key is not valid. Falling back to the default API key."];
+                [RSLogger logError:@"BrazeIntegration: Configured to use platform-specific App Identifier Keys but iOS App Identifier Key is not valid. Falling back to the Default App Identifier Key."];
             }
         }
         connectionMode = [self getConnectionMode:config];
 
-        if ([apiKey length] == 0) {
-            [RSLogger logError:@"API Key is invalid. Aborting Braze SDK initalisation."];
+        if ([appIdentifierKey length] == 0) {
+            [RSLogger logError:@"App Identifier Key is invalid. Aborting Braze SDK initialization."];
             return nil;
         }
 
@@ -73,7 +73,7 @@ static Braze *rsBrazeInstance;
             }
         }
         
-        BRZConfiguration *configuration = [[BRZConfiguration alloc] initWithApiKey:apiKey
+        BRZConfiguration *configuration = [[BRZConfiguration alloc] initWithApiKey:appIdentifierKey
                                                                           endpoint:brazeEndPoint];
         
         // For more details on Braze log level -> https://www.braze.com/docs/developer_guide/platform_integration_guides/swift/initial_sdk_setup/other_sdk_customizations/#braze-log-level

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   4.2.0 (2026-01-02)<br> * fix(braze): rename API Key to App Identifier Key terminology ([19ccbdd](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/19ccbdd))<br> * Merge pull request  68 from rudderlabs/release/4.2.0 ([daa3482](https://github.com/rudderlabs/rudder-integration-braze-ios/commit/daa3482)), closes [ 68](https://github.com/rudderlabs/rudder-integration-braze-ios/issues/68)