### PR TITLE
feat: update braze ios sdk version to v13.3.0

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - BrazeKit (12.0.3)
-  - BrazeUI (12.0.3):
-    - BrazeKit (= 12.0.3)
+  - BrazeKit (13.3.0)
+  - BrazeUI (13.3.0):
+    - BrazeKit (= 13.3.0)
   - MetricsReporter (2.0.0):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.1):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Braze (4.0.0):
-    - BrazeKit (~> 12.0.0)
+  - Rudder-Braze (4.2.1):
+    - BrazeKit (~> 13.3)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
 
@@ -31,12 +31,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: 44fab385edca94faaf96d7ce9f020b9c2ad3505e
-  BrazeUI: 8d107fe48a924d4e34bb8590a465082a822c20f7
+  BrazeKit: 53ac2d77c7d5ab54ab73df75c9058ae89236fc54
+  BrazeUI: 4de47810a95f225e0199cf6ddc9756f9dab662eb
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Braze: 04aac140b914b8b24925b11a3c4a935ba678aa71
+  Rudder-Braze: 03ed5148be07836ac9ee5c1040858f1533120d4c
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: d5cb3999cad3c9449f37674bd32ddede28c1f721

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static",
         "state": {
           "branch": null,
-          "revision": "c7e71206f50a6581686ab59dfc9ebf953c1f06d1",
-          "version": "12.0.0"
+          "revision": "e369c24537be87ac4ebaaeb958397036828b6ede",
+          "version": "13.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Rudder-Braze"]),
     ],
     dependencies: [
-        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", .exact("12.0.0")),
+        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", .upToNextMajor(from: "13.3.0")),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", "1.26.0"..<"2.0.0")
     ],
     targets: [

--- a/Rudder-Braze.podspec
+++ b/Rudder-Braze.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-braze_kit = '~> 12.0.0'
+braze_kit = '~> 13.3'
 rudder_sdk_version = '~> 1.26'
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Braze'


### PR DESCRIPTION
# Description

Updates the Braze iOS SDK dependency from version 12.0.x to 13.3.0 across all package managers.

  Changes:
  - Updated BrazeKit dependency from ~> 12.0.0 to ~> 13.3 in CocoaPods (.podspec)
  - Updated Swift Package Manager dependency from .exact("12.0.0") to .upToNextMajor(from: "13.3.0")
  - Updated Package.resolved and Podfile.lock with new versions
