### PR TITLE
feat: update braze kit version to 14.0.1 and above

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - BrazeKit (13.3.0)
-  - BrazeUI (13.3.0):
-    - BrazeKit (= 13.3.0)
+  - BrazeKit (14.0.3)
+  - BrazeUI (14.0.3):
+    - BrazeKit (= 14.0.3)
   - MetricsReporter (2.0.0):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.1):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Braze (4.2.1):
-    - BrazeKit (~> 13.3)
+  - Rudder-Braze (4.3.0):
+    - BrazeKit (< 15.0.0, >= 14.0.1)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
 
@@ -31,12 +31,12 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BrazeKit: 53ac2d77c7d5ab54ab73df75c9058ae89236fc54
-  BrazeUI: 4de47810a95f225e0199cf6ddc9756f9dab662eb
+  BrazeKit: 3f92e7b676f20b9a4aeb8246d46dfa461ceb73cd
+  BrazeUI: b29cdcdc5841179464b88d69f2c83c6c804cedc1
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Braze: 03ed5148be07836ac9ee5c1040858f1533120d4c
+  Rudder-Braze: 9a443e20b40de108d3a0fb4a452f67eba20a0e95
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: d5cb3999cad3c9449f37674bd32ddede28c1f721

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static",
         "state": {
           "branch": null,
-          "revision": "e369c24537be87ac4ebaaeb958397036828b6ede",
-          "version": "13.3.0"
+          "revision": "4e1b2ac0bc650ece9a2c82f3b3ad5b25573eed5a",
+          "version": "14.0.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Rudder-Braze"]),
     ],
     dependencies: [
-        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", "14.0.1"..<"15.0.0"),
+        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", .upToNextMajor(from: "14.0.1")),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", "1.26.0"..<"2.0.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["Rudder-Braze"]),
     ],
     dependencies: [
-        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", .upToNextMajor(from: "13.3.0")),
+        .package(name: "braze-swift-sdk", url: "https://github.com/braze-inc/braze-swift-sdk-prebuilt-static", "14.0.1"..<"15.0.0"),
         .package(name: "Rudder", url: "https://github.com/rudderlabs/rudder-sdk-ios", "1.26.0"..<"2.0.0")
     ],
     targets: [

--- a/Rudder-Braze.podspec
+++ b/Rudder-Braze.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-braze_kit = '~> 13.3'
+braze_kit = ['>= 14.0.1', '< 15.0.0']
 rudder_sdk_version = '~> 1.26'
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Braze'
@@ -37,6 +37,6 @@ Rudder is a platform for collecting, storing and routing customer event data to 
   end
 
   s.dependency 'Rudder', rudder_sdk_version
-  s.dependency 'BrazeKit', braze_kit
+  s.dependency 'BrazeKit', *Array(braze_kit)
 end
 


### PR DESCRIPTION
## Description
Update BrazeKit dependency from version `~> 13.3` (>=13.3.0, <14.0.0) to `>= 14.0.1, < 15.0.0` across both CocoaPods (podspec) and Swift Package Manager (Package.swift). This bumps the Braze SDK to the 14.x major version line.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Rudder-Braze.podspec**: Changed `braze_kit` from `'~> 13.3'` to `['>= 14.0.1', '< 15.0.0']` and updated the dependency line to use `*Array(braze_kit)` for proper splatting of array-based version constraints while maintaining backward compatibility with string-based user overrides via `$BrazeKit`.
- **Package.swift**: Changed the `braze-swift-sdk` dependency from `.upToNextMajor(from: "13.3.0")` to `"14.0.1"..<"15.0.0"`.
- **Package.resolved**: Resolved version updated from `13.3.0` to `14.0.3`.
- **Example/Podfile.lock**: Updated locked versions of `BrazeKit` and `BrazeUI` from `13.3.0` to `14.0.3`.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. Run `pod install` in the `Example/` directory.
2. Open `Example/Rudder-Braze.xcworkspace` in Xcode.
3. Build and run the Example app on an iOS Simulator.
4. Verify the app compiles and launches without errors.
5. Run `pod spec lint Rudder-Braze.podspec --allow-warnings` to validate the podspec.
6. Run `swift package resolve` to validate SPM resolution.

## Breaking Changes
- **Major version bump of BrazeKit from 13.x to 14.x**: Consumers pinned to BrazeKit 13.x will need to update. Several Braze APIs used in `RudderBrazeIntegration.m` are now deprecated in 14.x (e.g., `setCustomAttributeWithKey:andBOOLValue:`, `logCustomEvent:withProperties:`, `logPurchase:inCurrency:atPrice:withQuantity:andProperties:`). These still compile but should be migrated to their replacements in a follow-up.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- The podspec validation (`pod spec lint`) passes successfully with `--allow-warnings`.
- The Example project builds successfully via `xcodebuild` against the simulator target.
- BrazeKit resolved to version `14.0.3` (latest available in the 14.0.1..<15.0.0 range).
