### PR TITLE
feat(ecommerce): braze recommended ecommerce events in device mode

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,4 +7,8 @@ platform :ios, '13.0'
 target 'Rudder-Braze_Example' do
   pod 'Rudder-Braze', :path => '../'
   pod 'BrazeUI' # Used to enable Braze IAM (In-App Message)
+
+  target 'Rudder-Braze_Tests' do
+    inherit! :search_paths
+  end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.1):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Braze (4.3.0):
+  - Rudder-Braze (4.4.0):
     - BrazeKit (< 15.0.0, >= 14.0.1)
     - Rudder (~> 1.26)
   - RudderKit (1.4.0)
@@ -36,9 +36,9 @@ SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Braze: 9a443e20b40de108d3a0fb4a452f67eba20a0e95
+  Rudder-Braze: 2371de6a4fbee74df5a2e9656995675a667062b9
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
-PODFILE CHECKSUM: d5cb3999cad3c9449f37674bd32ddede28c1f721
+PODFILE CHECKSUM: 6e5cea33d79e492fb5ac112b1d7d81a6791fbf62
 
 COCOAPODS: 1.16.2

--- a/Example/Rudder-Braze.xcodeproj/project.pbxproj
+++ b/Example/Rudder-Braze.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		8CBF2B682AA1045600A58EFF /* ExamplePush.apns in Resources */ = {isa = PBXBuildFile; fileRef = 8CBF2B672AA1045600A58EFF /* ExamplePush.apns */; };
+		8F64CD9A394B29BBB30C5178 /* Pods_Rudder_Braze_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B07600495E853FDA011CF865 /* Pods_Rudder_Braze_Tests.framework */; };
 		CF593CFF39785FD1434D0755 /* Pods_Rudder_Braze_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D95D1EF4A7416C54D00CAFB /* Pods_Rudder_Braze_Example.framework */; };
 		EDA2C5C029C4339000B7FF42 /* SampleRudderConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = EDA2C5BD29C4339000B7FF42 /* SampleRudderConfig.plist */; };
 		EDA2C5C429C4341D00B7FF42 /* RudderConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA2C5C329C4341D00B7FF42 /* RudderConfig.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		264FC1B2440B8D3CF6D3DD9A /* Pods-Rudder-Braze_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-Braze_Tests.release.xcconfig"; path = "Target Support Files/Pods-Rudder-Braze_Tests/Pods-Rudder-Braze_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		5D95D1EF4A7416C54D00CAFB /* Pods_Rudder_Braze_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_Braze_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58A195388D20070C39A /* Rudder-Braze_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Rudder-Braze_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6003F58D195388D20070C39A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -62,9 +64,11 @@
 		61CBF84E5B022B048B864854 /* Pods-Rudder-Braze_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-Braze_Example.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-Braze_Example/Pods-Rudder-Braze_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		878BB5C78838CA7BFDDA0191 /* Pods-Rudder-Braze_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-Braze_Tests.debug.xcconfig"; path = "Target Support Files/Pods-Rudder-Braze_Tests/Pods-Rudder-Braze_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		8CBF2B662AA0ED7A00A58EFF /* Rudder-Braze_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Rudder-Braze_Example.entitlements"; sourceTree = "<group>"; };
 		8CBF2B672AA1045600A58EFF /* ExamplePush.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = ExamplePush.apns; sourceTree = "<group>"; };
 		9D41BA55C48AAEED1267EB26 /* Rudder-Braze.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Rudder-Braze.podspec"; path = "../Rudder-Braze.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		B07600495E853FDA011CF865 /* Pods_Rudder_Braze_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rudder_Braze_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA3AB6DAB2233FE3AB2FF006 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		CCEC7FA67182AB4FB2230DB5 /* Pods-Rudder-Braze_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rudder-Braze_Example.release.xcconfig"; path = "Target Support Files/Pods-Rudder-Braze_Example/Pods-Rudder-Braze_Example.release.xcconfig"; sourceTree = "<group>"; };
 		EDA2C59829BAFA9800B7FF42 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CONTRIBUTING.md; path = ../CONTRIBUTING.md; sourceTree = "<group>"; };
@@ -105,6 +109,7 @@
 				6003F5B0195388D20070C39A /* XCTest.framework in Frameworks */,
 				6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */,
 				6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */,
+				8F64CD9A394B29BBB30C5178 /* Pods_Rudder_Braze_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,6 +146,7 @@
 				6003F591195388D20070C39A /* UIKit.framework */,
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				5D95D1EF4A7416C54D00CAFB /* Pods_Rudder_Braze_Example.framework */,
+				B07600495E853FDA011CF865 /* Pods_Rudder_Braze_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -213,6 +219,8 @@
 			children = (
 				61CBF84E5B022B048B864854 /* Pods-Rudder-Braze_Example.debug.xcconfig */,
 				CCEC7FA67182AB4FB2230DB5 /* Pods-Rudder-Braze_Example.release.xcconfig */,
+				878BB5C78838CA7BFDDA0191 /* Pods-Rudder-Braze_Tests.debug.xcconfig */,
+				264FC1B2440B8D3CF6D3DD9A /* Pods-Rudder-Braze_Tests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -278,6 +286,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5C2195388D20070C39A /* Build configuration list for PBXNativeTarget "Rudder-Braze_Tests" */;
 			buildPhases = (
+				DD5B5D1C9D16315622CC55A6 /* [CP] Check Pods Manifest.lock */,
 				6003F5AA195388D20070C39A /* Sources */,
 				6003F5AB195388D20070C39A /* Frameworks */,
 				6003F5AC195388D20070C39A /* Resources */,
@@ -421,6 +430,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Rudder-Braze_Example/Pods-Rudder-Braze_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DD5B5D1C9D16315622CC55A6 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Rudder-Braze_Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -635,6 +666,7 @@
 		};
 		6003F5C3195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 878BB5C78838CA7BFDDA0191 /* Pods-Rudder-Braze_Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -660,6 +692,7 @@
 		};
 		6003F5C4195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 264FC1B2440B8D3CF6D3DD9A /* Pods-Rudder-Braze_Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";

--- a/Example/Tests/Tests-Prefix.pch
+++ b/Example/Tests/Tests-Prefix.pch
@@ -2,6 +2,4 @@
 
 #ifdef __OBJC__
 
-  @import FBSnapshotTestCase;
-
 #endif

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -1,35 +1,204 @@
 //
-//  Rudder-AdjustTests.m
-//  Rudder-AdjustTests
+//  Tests.m
+//  Rudder-Braze
 //
-//  Created by arnab on 10/29/2019.
-//  Copyright (c) 2019 arnab. All rights reserved.
+//  Unit tests for the recommended-ecommerce mapping in RudderBrazeEcommerceUtils. The array
+//  assertions (products / discounts / type come back as NSArrays) guard the contract that the
+//  dictionary handed to Braze's logCustomEvent:properties: keeps its arrays intact.
 //
 
 @import XCTest;
+@import Rudder_Braze;
 
 @interface Tests : XCTestCase
-
 @end
 
 @implementation Tests
 
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+#pragma mark - helpers
+
+- (NSDictionary *)buildForEvent:(NSString *)eventName properties:(NSDictionary *)props {
+    RudderBrazeEcommerceEvent *event = [RudderBrazeEcommerceUtils resolveEcommerceEvent:eventName];
+    XCTAssertNotNil(event, @"expected a mapped event for %@", eventName);
+    return [RudderBrazeEcommerceUtils buildEcommerceProperties:event properties:props];
 }
 
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
+- (NSDictionary *)buildOrderCompleted:(NSDictionary *)props {
+    return [self buildForEvent:@"Order Completed" properties:props];
 }
 
-- (void)testExample
-{
-    XCTFail(@"No implementation for \"%s\"", __PRETTY_FUNCTION__);
+- (NSDictionary *)firstProduct:(NSDictionary *)out {
+    NSArray *products = out[@"products"];
+    XCTAssertTrue([products isKindOfClass:[NSArray class]]);
+    XCTAssertGreaterThan(products.count, 0u);
+    return products[0];
+}
+
+#pragma mark - resolveEcommerceEvent
+
+- (void)testResolveEcommerceEventCaseInsensitive {
+    XCTAssertEqualObjects([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Order Completed"].brazeEvent, @"ecommerce.order_placed");
+    XCTAssertEqualObjects([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"order completed"].brazeEvent, @"ecommerce.order_placed");
+    XCTAssertEqualObjects([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"  Order Completed  "].brazeEvent, @"ecommerce.order_placed");
+    XCTAssertEqualObjects([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Product Viewed"].brazeEvent, @"ecommerce.product_viewed");
+
+    RudderBrazeEcommerceEvent *added = [RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Product Added"];
+    XCTAssertEqualObjects(added.brazeEvent, @"ecommerce.cart_updated");
+    XCTAssertEqualObjects(added.action, @"add");
+    XCTAssertEqualObjects([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Product Removed"].action, @"remove");
+}
+
+- (void)testResolveEcommerceEventReturnsNilForUnmapped {
+    // Product Clicked and Cart Viewed intentionally stay generic custom events.
+    XCTAssertNil([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Product Clicked"]);
+    XCTAssertNil([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Cart Viewed"]);
+    XCTAssertNil([RudderBrazeEcommerceUtils resolveEcommerceEvent:@"Some Random Event"]);
+    XCTAssertNil([RudderBrazeEcommerceUtils resolveEcommerceEvent:nil]);
+}
+
+#pragma mark - Order Completed -> ecommerce.order_placed
+
+- (void)testOrderCompletedMapsCoreFieldsAndProducts {
+    NSDictionary *out = [self buildOrderCompleted:@{
+        @"order_id": @"O-100",
+        @"total": @200,
+        @"currency": @"USD",
+        @"products": @[@{
+            @"product_id": @"P1",
+            @"name": @"Mug",
+            @"price": @12.5,
+            @"quantity": @3,
+        }],
+    }];
+
+    XCTAssertEqualObjects(out[@"order_id"], @"O-100");
+    XCTAssertEqualObjects(out[@"currency"], @"USD");
+    XCTAssertEqual([out[@"total_value"] intValue], 200);
+    XCTAssertEqualObjects(out[@"source"], @"ios");
+
+    NSDictionary *product = [self firstProduct:out];
+    XCTAssertEqualObjects(product[@"product_id"], @"P1");
+    XCTAssertEqualObjects(product[@"product_name"], @"Mug");
+    // variant_id falls back to sku -> product_id when absent.
+    XCTAssertEqualObjects(product[@"variant_id"], @"P1");
+    XCTAssertEqualWithAccuracy([product[@"price"] doubleValue], 12.5, 0.0001);
+    XCTAssertEqual([product[@"quantity"] intValue], 3);
+}
+
+- (void)testOrderCompletedTotalValueFallback {
+    // Dictionaries are bound to locals first: commas inside an inline @{...} literal would be parsed
+    // as extra XCTAssert macro arguments.
+    NSDictionary *all = @{@"total": @200, @"revenue": @1, @"value": @2};
+    NSDictionary *revenueValue = @{@"revenue": @50, @"value": @2};
+    NSDictionary *valueOnly = @{@"value": @30};
+    XCTAssertEqual([[self buildOrderCompleted:all][@"total_value"] intValue], 200);
+    XCTAssertEqual([[self buildOrderCompleted:revenueValue][@"total_value"] intValue], 50);
+    XCTAssertEqual([[self buildOrderCompleted:valueOnly][@"total_value"] intValue], 30);
+}
+
+#pragma mark - metadata pass-through
+
+- (void)testMetadataRoutesUnmappedKeysAndSkipsNull {
+    NSDictionary *out = [self buildOrderCompleted:@{
+        @"order_id": @"O-100",
+        @"affiliation": @"web-store",        // unmapped top-level -> metadata
+        @"ignored_null": [NSNull null],      // NSNull must be filtered, not copied
+        @"products": @[@{
+            @"product_id": @"P1",
+            @"color": @"blue",               // unmapped product key -> products[].metadata
+        }],
+    }];
+
+    XCTAssertNil(out[@"affiliation"]);
+    NSDictionary *metadata = out[@"metadata"];
+    XCTAssertEqualObjects(metadata[@"affiliation"], @"web-store");
+    XCTAssertNil(metadata[@"ignored_null"]);
+
+    NSDictionary *product = [self firstProduct:out];
+    XCTAssertNil(product[@"color"]);
+    XCTAssertEqualObjects(product[@"metadata"][@"color"], @"blue");
+}
+
+#pragma mark - coercion
+
+- (void)testCoercionNumericStringsAndNumbers {
+    NSDictionary *out = [self buildOrderCompleted:@{
+        @"total": @"199.99",                 // FLOAT, numeric string -> number
+        @"products": @[@{
+            @"product_id": @1001,            // STRING, number -> string
+            @"price": @"12.5",               // FLOAT, numeric string -> number
+            @"quantity": @"3",               // INTEGER, numeric string -> number
+        }],
+    }];
+
+    XCTAssertEqualWithAccuracy([out[@"total_value"] doubleValue], 199.99, 0.0001);
+
+    NSDictionary *product = [self firstProduct:out];
+    XCTAssertTrue([product[@"product_id"] isKindOfClass:[NSString class]]);
+    XCTAssertEqualObjects(product[@"product_id"], @"1001");
+    XCTAssertEqualWithAccuracy([product[@"price"] doubleValue], 12.5, 0.0001);
+    XCTAssertEqual([product[@"quantity"] intValue], 3);
+}
+
+- (void)testCoercionUnparsableLeftAsIs {
+    // "free" cannot be coerced to a FLOAT price; it is sent verbatim (warned, never dropped).
+    NSDictionary *product = [self firstProduct:[self buildOrderCompleted:@{
+        @"order_id": @"O-100",
+        @"products": @[@{@"product_id": @"P1", @"price": @"free"}],
+    }]];
+    XCTAssertEqualObjects(product[@"price"], @"free");
+}
+
+#pragma mark - empty products
+
+- (void)testEmptyProductsAreOmitted {
+    // An all-empty products array must be treated as "no products" (key omitted).
+    NSDictionary *out = [self buildOrderCompleted:@{@"order_id": @"O-100", @"products": @[@{}]}];
+    XCTAssertNil(out[@"products"]);
+
+    // A mix keeps only the non-empty product.
+    NSDictionary *mixed = [self buildOrderCompleted:@{@"order_id": @"O-100", @"products": @[@{}, @{@"product_id": @"P1"}]}];
+    NSArray *products = mixed[@"products"];
+    XCTAssertEqual(products.count, 1u);
+    XCTAssertEqualObjects(products[0][@"product_id"], @"P1");
+}
+
+#pragma mark - arrays preserved (the #1 guard)
+
+- (void)testProductsAndDiscountsStayArrays {
+    NSDictionary *out = [self buildOrderCompleted:@{
+        @"order_id": @"O-100",
+        @"total": @200,
+        @"currency": @"USD",
+        @"discounts": @[@{@"code": @"WELCOME", @"amount": @15}],
+        @"products": @[
+            @{@"product_id": @"P1", @"name": @"Mug"},
+            @{@"product_id": @"P2", @"name": @"Saucer"},
+        ],
+    }];
+
+    XCTAssertTrue([out[@"products"] isKindOfClass:[NSArray class]]);
+    NSArray *products = out[@"products"];
+    XCTAssertEqual(products.count, 2u);
+    XCTAssertTrue([products[0] isKindOfClass:[NSDictionary class]]);
+    XCTAssertEqualObjects(products[0][@"product_id"], @"P1");
+
+    XCTAssertTrue([out[@"discounts"] isKindOfClass:[NSArray class]]);
+    XCTAssertEqual([out[@"discounts"] count], 1u);
+}
+
+- (void)testTypeStringArrayStaysArray {
+    // product_viewed's "type" is a STRING_ARRAY; it must stay an NSArray.
+    NSDictionary *out = [self buildForEvent:@"Product Viewed" properties:@{
+        @"product_id": @"PV1",
+        @"type": @[@"shoe", @"running"],
+    }];
+
+    XCTAssertTrue([out[@"type"] isKindOfClass:[NSArray class]]);
+    NSArray *type = out[@"type"];
+    XCTAssertEqual(type.count, 2u);
+    XCTAssertEqualObjects(type[0], @"shoe");
+    XCTAssertEqualObjects(type[1], @"running");
 }
 
 @end
-

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -201,4 +201,67 @@
     XCTAssertEqualObjects(type[1], @"running");
 }
 
+#pragma mark - malformed products -> metadata (never dropped)
+
+- (void)testMalformedProductsValueFlowsToMetadata {
+    // A non-array `products` must not be silently dropped; it is preserved under metadata.
+    NSDictionary *out = [self buildOrderCompleted:@{
+        @"order_id": @"O-100",
+        @"products": @"not-an-array",
+    }];
+    XCTAssertNil(out[@"products"]);
+    XCTAssertEqualObjects(out[@"metadata"][@"products"], @"not-an-array");
+}
+
+- (void)testMixedProductsArrayFlowsToMetadata {
+    // An array containing a non-object element is treated as malformed (all-or-nothing) and preserved
+    // under metadata rather than partially mapped.
+    NSArray *mixed = @[@{@"product_id": @"P1"}, @"junk"];
+    NSDictionary *props = @{@"order_id": @"O-100", @"products": mixed};
+    NSDictionary *out = [self buildOrderCompleted:props];
+    XCTAssertNil(out[@"products"]);
+    XCTAssertEqualObjects(out[@"metadata"][@"products"], mixed);
+}
+
+#pragma mark - cart_updated products[]
+
+- (void)testCartUpdatedMapsExplicitProductsArray {
+    // An explicit products[] on Product Added is mapped item-by-item (not folded from top-level fields).
+    NSDictionary *props = @{
+        @"cart_id": @"C-1",
+        @"products": @[
+            @{@"product_id": @"P1", @"name": @"Mug"},
+            @{@"product_id": @"P2", @"name": @"Saucer"},
+        ],
+    };
+    NSDictionary *out = [self buildForEvent:@"Product Added" properties:props];
+
+    XCTAssertEqualObjects(out[@"action"], @"add");
+    NSArray *products = out[@"products"];
+    XCTAssertTrue([products isKindOfClass:[NSArray class]]);
+    XCTAssertEqual(products.count, 2u);
+    XCTAssertEqualObjects(products[0][@"product_id"], @"P1");
+    XCTAssertEqualObjects(products[0][@"product_name"], @"Mug");
+    XCTAssertEqualObjects(products[1][@"product_id"], @"P2");
+    // products[] is consumed, so it is not duplicated into metadata.
+    XCTAssertNil(out[@"metadata"][@"products"]);
+}
+
+- (void)testCartUpdatedFallsBackToTopLevelProduct {
+    // Without products[], top-level product fields fold into a single-element products array.
+    NSDictionary *props = @{
+        @"cart_id": @"C-1",
+        @"product_id": @"P1",
+        @"name": @"Mug",
+        @"price": @9.99,
+    };
+    NSDictionary *out = [self buildForEvent:@"Product Removed" properties:props];
+
+    XCTAssertEqualObjects(out[@"action"], @"remove");
+    NSArray *products = out[@"products"];
+    XCTAssertEqual(products.count, 1u);
+    XCTAssertEqualObjects(products[0][@"product_id"], @"P1");
+    XCTAssertEqualObjects(products[0][@"product_name"], @"Mug");
+}
+
 @end

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.h
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.h
@@ -1,17 +1,12 @@
 //
 //  RudderBrazeEcommerceUtils.h
 //
-//  Stateless mapping logic for Braze recommended ecommerce events (gated by
-//  useRecommendedEcommerceEvents). Mirrors the Android/Kotlin device-mode implementation; the
-//  actual braze logCustomEvent:withProperties: call stays in RudderBrazeIntegration.
-//
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-// Descriptor for a Braze recommended ecommerce event. action is non-nil only for cart_updated
-// (Product Added -> add, Product Removed -> remove).
+// Descriptor for a Braze recommended ecommerce event. action is set only for cart_updated.
 @interface RudderBrazeEcommerceEvent : NSObject
 
 @property (nonatomic, copy, readonly) NSString *brazeEvent;
@@ -21,13 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RudderBrazeEcommerceUtils : NSObject
 
-// Resolves a RudderStack event name to its Braze recommended event (case-insensitive).
-// Returns nil for events without a recommended-event counterpart.
+// Resolves a RudderStack event name to its Braze recommended event, or nil if there is none.
 + (nullable RudderBrazeEcommerceEvent *)resolveEcommerceEvent:(nullable NSString *)eventName;
 
-// Builds the Braze custom-event property dictionary for a recommended ecommerce event.
-// Send-anyway posture (D5): builds from an empty map when properties are absent so the event is
-// still logged (with required-field warnings) rather than dropped.
 + (NSDictionary<NSString *, id> *)buildEcommerceProperties:(RudderBrazeEcommerceEvent *)ecommerceEvent
                                                 properties:(nullable NSDictionary<NSString *, id> *)properties;
 

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.h
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.h
@@ -1,0 +1,36 @@
+//
+//  RudderBrazeEcommerceUtils.h
+//
+//  Stateless mapping logic for Braze recommended ecommerce events (gated by
+//  useRecommendedEcommerceEvents). Mirrors the Android/Kotlin device-mode implementation; the
+//  actual braze logCustomEvent:withProperties: call stays in RudderBrazeIntegration.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Descriptor for a Braze recommended ecommerce event. action is non-nil only for cart_updated
+// (Product Added -> add, Product Removed -> remove).
+@interface RudderBrazeEcommerceEvent : NSObject
+
+@property (nonatomic, copy, readonly) NSString *brazeEvent;
+@property (nonatomic, copy, readonly, nullable) NSString *action;
+
+@end
+
+@interface RudderBrazeEcommerceUtils : NSObject
+
+// Resolves a RudderStack event name to its Braze recommended event (case-insensitive).
+// Returns nil for events without a recommended-event counterpart.
++ (nullable RudderBrazeEcommerceEvent *)resolveEcommerceEvent:(nullable NSString *)eventName;
+
+// Builds the Braze custom-event property dictionary for a recommended ecommerce event.
+// Send-anyway posture (D5): builds from an empty map when properties are absent so the event is
+// still logged (with required-field warnings) rather than dropped.
++ (NSDictionary<NSString *, id> *)buildEcommerceProperties:(RudderBrazeEcommerceEvent *)ecommerceEvent
+                                                properties:(nullable NSDictionary<NSString *, id> *)properties;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -56,18 +56,21 @@ static NSString *const ACTION_REMOVE = @"remove";
 static NSString *const SOURCE_KEY = @"source";
 static NSString *const SOURCE = @"ios";
 
-// RudderStack ecommerce source keys.
-static NSString *const EC_PRODUCT_ID = @"product_id";
-static NSString *const EC_QUANTITY = @"quantity";
-static NSString *const EC_PRICE = @"price";
-static NSString *const EC_CURRENCY = @"currency";
-static NSString *const EC_PRODUCTS = @"products";
-static NSString *const EC_CART_ID = @"cart_id";
-static NSString *const EC_CHECKOUT_ID = @"checkout_id";
-static NSString *const EC_ORDER_ID = @"order_id";
-static NSString *const EC_TOTAL = @"total";
-static NSString *const EC_REVENUE = @"revenue";
-static NSString *const EC_DISCOUNT = @"discount";
+// RudderStack ecommerce source keys. Keys the SDK exposes come from RSECommerceParamNames
+// (imported via Rudder.h); the rest have no SDK constant and use the RS spec field name.
+#define EC_PRODUCT_ID  KeyProductId
+#define EC_QUANTITY    KeyQuantity
+#define EC_PRICE       KeyPrice
+#define EC_CURRENCY    KeyCurrency
+#define EC_PRODUCTS    KeyProducts
+#define EC_CART_ID     KeyCartId
+#define EC_CHECKOUT_ID KeyCheckoutId
+#define EC_ORDER_ID    KeyOrderId
+#define EC_TOTAL       KeyTotal
+#define EC_REVENUE     KeyRevenue
+#define EC_DISCOUNT    KeyDiscount
+#define EC_REASON      KeyReason
+
 static NSString *const EC_SKU = @"sku";
 static NSString *const EC_NAME = @"name";
 static NSString *const EC_VARIANT = @"variant";
@@ -81,7 +84,6 @@ static NSString *const EC_SUBTOTAL_VALUE = @"subtotal_value";
 static NSString *const EC_DISCOUNTS = @"discounts";
 static NSString *const EC_TOTAL_DISCOUNTS = @"total_discounts";
 static NSString *const EC_CANCEL_REASON = @"cancel_reason";
-static NSString *const EC_REASON = @"reason";
 
 // Braze recommended-event field names.
 static NSString *const BRAZE_PRODUCT_ID = @"product_id";
@@ -159,14 +161,15 @@ static NSString *const BRAZE_METADATA = @"metadata";
 + (NSDictionary<NSString *, RudderBrazeEcommerceEvent *> *)ecommerceEventMapping {
     static NSDictionary *mapping; static dispatch_once_t t;
     dispatch_once(&t, ^{
+        // Keyed off the SDK's RSECommerceEvents names (lowercased for case-insensitive lookup).
         mapping = @{
-            @"product viewed":    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductViewed brazeEvent:BRAZE_EVENT_PRODUCT_VIEWED action:nil],
-            @"product added":     [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductAdded brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_ADD],
-            @"product removed":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductRemoved brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_REMOVE],
-            @"checkout started":  [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeCheckoutStarted brazeEvent:BRAZE_EVENT_CHECKOUT_STARTED action:nil],
-            @"order completed":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCompleted brazeEvent:BRAZE_EVENT_ORDER_PLACED action:nil],
-            @"order refunded":    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderRefunded brazeEvent:BRAZE_EVENT_ORDER_REFUNDED action:nil],
-            @"order cancelled":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCancelled brazeEvent:BRAZE_EVENT_ORDER_CANCELLED action:nil],
+            [ECommProductViewed lowercaseString]:   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductViewed brazeEvent:BRAZE_EVENT_PRODUCT_VIEWED action:nil],
+            [ECommProductAdded lowercaseString]:    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductAdded brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_ADD],
+            [ECommProductRemoved lowercaseString]:  [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductRemoved brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_REMOVE],
+            [ECommCheckoutStarted lowercaseString]: [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeCheckoutStarted brazeEvent:BRAZE_EVENT_CHECKOUT_STARTED action:nil],
+            [ECommOrderCompleted lowercaseString]:  [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCompleted brazeEvent:BRAZE_EVENT_ORDER_PLACED action:nil],
+            [ECommOrderRefunded lowercaseString]:   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderRefunded brazeEvent:BRAZE_EVENT_ORDER_REFUNDED action:nil],
+            [ECommOrderCancelled lowercaseString]:  [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCancelled brazeEvent:BRAZE_EVENT_ORDER_CANCELLED action:nil],
         };
     });
     return mapping;

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -155,9 +155,15 @@ static NSNumber *parseLongOrNil(NSString *string);
     return keys;
 }
 
-+ (NSSet<NSString *> *)cartUpdatedConsumedKeys {
-    static NSSet *keys; static dispatch_once_t t;
-    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_CART_ID, EC_CURRENCY, EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING]]; });
+// Cart-level keys are always consumed. With an explicit products[] its items are mapped and `products`
+// is consumed; otherwise the top-level product fields are folded into products[0] and consumed instead.
++ (NSSet<NSString *> *)cartUpdatedConsumedKeys:(NSDictionary *)props {
+    NSMutableSet *keys = [NSMutableSet setWithArray:@[EC_CART_ID, EC_CURRENCY, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING]];
+    if ([self explicitProductsArray:props] != nil) {
+        [keys addObject:EC_PRODUCTS];
+    } else {
+        [keys addObjectsFromArray:@[EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL]];
+    }
     return keys;
 }
 
@@ -183,6 +189,17 @@ static NSNumber *parseLongOrNil(NSString *string);
     static NSSet *keys; static dispatch_once_t t;
     dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_CANCEL_REASON, EC_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS]]; });
     return keys;
+}
+
+// `products` is consumed (kept out of metadata) only when it is an explicit array of objects we build
+// from. A non-array/malformed value is left unconsumed so it flows through to metadata, not dropped.
++ (NSSet<NSString *> *)consumedKeys:(NSSet<NSString *> *)base withProductsArrayFrom:(NSDictionary *)props {
+    if ([self explicitProductsArray:props] != nil) {
+        return base;
+    }
+    NSMutableSet *adjusted = [base mutableCopy];
+    [adjusted removeObject:EC_PRODUCTS];
+    return adjusted;
 }
 
 #pragma mark - Resolution
@@ -277,19 +294,28 @@ static NSNumber *parseLongOrNil(NSString *string);
     return out;
 }
 
-// A single top-level product is wrapped into a 1-element products array; action distinguishes
-// add from remove.
+// cart_updated maps an explicit products[] item-by-item when present; otherwise the top-level product
+// fields are folded into a single-element products array. action distinguishes add from remove.
 + (NSDictionary<NSString *, id> *)buildCartUpdated:(NSDictionary *)props action:(NSString *)action {
     NSString *brazeEvent = BRAZE_EVENT_CART_UPDATED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
 
     id cartId = firstNonNull(props, @[EC_CART_ID]);
     id currency = firstNonNull(props, @[EC_CURRENCY]);
-    NSMutableDictionary *product = [self buildProductFields:props];
+
+    NSArray *products = nil;
+    if ([self explicitProductsArray:props] != nil) {
+        products = [self buildProducts:props];
+    } else {
+        NSMutableDictionary *product = [self buildProductFields:props];
+        if (product.count > 0) {
+            products = @[product];
+        }
+    }
 
     warnIfMissing(brazeEvent, BRAZE_CART_ID, cartId);
     warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
-    if (product.count == 0) {
+    if (products == nil) {
         warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
     }
 
@@ -300,12 +326,12 @@ static NSNumber *parseLongOrNil(NSString *string);
     putIfPresent(out, BRAZE_TAX, firstNonNull(props, @[EC_TAX]));
     putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
     out[BRAZE_ACTION] = action;
-    if (product.count > 0) {
-        out[BRAZE_PRODUCTS] = @[product];
+    if (products != nil) {
+        out[BRAZE_PRODUCTS] = products;
     }
     out[SOURCE_KEY] = SOURCE;
 
-    putMetadata(out, props, [self cartUpdatedConsumedKeys]);
+    putMetadata(out, props, [self cartUpdatedConsumedKeys:props]);
     return out;
 }
 
@@ -337,7 +363,7 @@ static NSNumber *parseLongOrNil(NSString *string);
     putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
     out[SOURCE_KEY] = SOURCE;
 
-    putMetadata(out, props, [self checkoutStartedConsumedKeys]);
+    putMetadata(out, props, [self consumedKeys:[self checkoutStartedConsumedKeys] withProductsArrayFrom:props]);
     return out;
 }
 
@@ -371,7 +397,7 @@ static NSNumber *parseLongOrNil(NSString *string);
     putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
     out[SOURCE_KEY] = SOURCE;
 
-    putMetadata(out, props, [self orderPlacedConsumedKeys]);
+    putMetadata(out, props, [self consumedKeys:[self orderPlacedConsumedKeys] withProductsArrayFrom:props]);
     return out;
 }
 
@@ -401,7 +427,7 @@ static NSNumber *parseLongOrNil(NSString *string);
     putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
     out[SOURCE_KEY] = SOURCE;
 
-    putMetadata(out, props, [self orderRefundedConsumedKeys]);
+    putMetadata(out, props, [self consumedKeys:[self orderRefundedConsumedKeys] withProductsArrayFrom:props]);
     return out;
 }
 
@@ -437,26 +463,39 @@ static NSNumber *parseLongOrNil(NSString *string);
     putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
     out[SOURCE_KEY] = SOURCE;
 
-    putMetadata(out, props, [self orderCancelledConsumedKeys]);
+    putMetadata(out, props, [self consumedKeys:[self orderCancelledConsumedKeys] withProductsArrayFrom:props]);
     return out;
 }
 
 #pragma mark - Products
 
-+ (nullable NSArray<NSDictionary *> *)buildProducts:(NSDictionary *)props {
+// Returns props[products] only when it is an array whose every element is an object. A non-array or
+// mixed/malformed array returns nil so the original value can flow through to metadata (never dropped).
++ (nullable NSArray<NSDictionary *> *)explicitProductsArray:(NSDictionary *)props {
     id raw = props[EC_PRODUCTS];
     if (![raw isKindOfClass:[NSArray class]]) {
         return nil;
     }
-    NSMutableArray *products = [NSMutableArray array];
     for (id item in (NSArray *)raw) {
-        if ([item isKindOfClass:[NSDictionary class]]) {
-            NSMutableDictionary *product = [self buildProduct:(NSDictionary *)item];
-            // Skip empty product maps so an all-empty products array is treated as "no products"
-            // (omitted + missing-field warning) rather than sending products: [ {} ].
-            if (product.count > 0) {
-                [products addObject:product];
-            }
+        if (![item isKindOfClass:[NSDictionary class]]) {
+            return nil;
+        }
+    }
+    return (NSArray *)raw;
+}
+
++ (nullable NSArray<NSDictionary *> *)buildProducts:(NSDictionary *)props {
+    NSArray<NSDictionary *> *raw = [self explicitProductsArray:props];
+    if (raw == nil) {
+        return nil;
+    }
+    NSMutableArray *products = [NSMutableArray array];
+    for (NSDictionary *item in raw) {
+        NSMutableDictionary *product = [self buildProduct:item];
+        // Skip empty product maps so an all-empty products array is treated as "no products"
+        // (omitted + missing-field warning) rather than sending products: [ {} ].
+        if (product.count > 0) {
+            [products addObject:product];
         }
     }
     return products.count > 0 ? products : nil;

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -109,6 +109,30 @@ static NSString *const BRAZE_SUBTOTAL_VALUE = @"subtotal_value";
 static NSString *const BRAZE_DISCOUNTS = @"discounts";
 static NSString *const BRAZE_METADATA = @"metadata";
 
+#pragma mark - Type coercion
+
+// The type Braze expects for a recommended-event field. Resolved values are coerced toward this type
+// where possible; an un-coercible value is sent verbatim and surfaced via a single warning per event.
+typedef NS_ENUM(NSInteger, RudderBrazeFieldType) {
+    RudderBrazeFieldTypeString,
+    RudderBrazeFieldTypeInteger,
+    RudderBrazeFieldTypeFloat,
+    RudderBrazeFieldTypeStringArray,
+    RudderBrazeFieldTypeArray
+};
+
+static NSArray<NSArray *> *fieldTypeTable(void);
+static void coerceAndWarnTypes(NSString *brazeEvent, NSMutableDictionary *out);
+static id coerceValue(id value, RudderBrazeFieldType type);
+static BOOL valueMatchesType(id value, RudderBrazeFieldType type);
+static BOOL isIntegralNumber(NSNumber *number);
+static BOOL isStringArray(id value);
+static BOOL isBooleanNumber(NSNumber *number);
+static NSString *numberToBrazeString(NSNumber *number);
+static NSString *fieldTypeName(RudderBrazeFieldType type);
+static NSNumber *parseDoubleOrNil(NSString *string);
+static NSNumber *parseLongOrNil(NSString *string);
+
 @implementation RudderBrazeEcommerceUtils
 
 #pragma mark - Consumed-key sets
@@ -188,22 +212,34 @@ static NSString *const BRAZE_METADATA = @"metadata";
 + (NSDictionary<NSString *, id> *)buildEcommerceProperties:(RudderBrazeEcommerceEvent *)ecommerceEvent
                                                 properties:(NSDictionary<NSString *, id> *)properties {
     NSDictionary *props = (properties != nil) ? properties : @{};
+    NSMutableDictionary *out = nil;
     switch (ecommerceEvent.type) {
         case RudderBrazeEcommerceEventTypeProductViewed:
-            return [self buildProductViewed:props];
+            out = (NSMutableDictionary *)[self buildProductViewed:props];
+            break;
         case RudderBrazeEcommerceEventTypeProductAdded:
         case RudderBrazeEcommerceEventTypeProductRemoved:
-            return [self buildCartUpdated:props action:ecommerceEvent.action];
+            out = (NSMutableDictionary *)[self buildCartUpdated:props action:ecommerceEvent.action];
+            break;
         case RudderBrazeEcommerceEventTypeCheckoutStarted:
-            return [self buildCheckoutStarted:props];
+            out = (NSMutableDictionary *)[self buildCheckoutStarted:props];
+            break;
         case RudderBrazeEcommerceEventTypeOrderCompleted:
-            return [self buildOrderPlaced:props];
+            out = (NSMutableDictionary *)[self buildOrderPlaced:props];
+            break;
         case RudderBrazeEcommerceEventTypeOrderRefunded:
-            return [self buildOrderRefunded:props];
+            out = (NSMutableDictionary *)[self buildOrderRefunded:props];
+            break;
         case RudderBrazeEcommerceEventTypeOrderCancelled:
-            return [self buildOrderCancelled:props];
+            out = (NSMutableDictionary *)[self buildOrderCancelled:props];
+            break;
     }
-    return [NSMutableDictionary dictionary];
+    if (out == nil) {
+        return [NSMutableDictionary dictionary];
+    }
+    // Coerce resolved values toward Braze's expected types and warn on any residual mismatch.
+    coerceAndWarnTypes(ecommerceEvent.brazeEvent, out);
+    return out;
 }
 
 + (NSDictionary<NSString *, id> *)buildProductViewed:(NSDictionary *)props {
@@ -481,6 +517,212 @@ static void warnIfMissing(NSString *brazeEvent, NSString *field, id value) {
             @"RudderBrazeIntegration: recommended event %@ is missing required field '%@'; sending event anyway.",
             brazeEvent, field]];
     }
+}
+
+#pragma mark - Type coercion
+
+// Each Braze field has exactly one expected type globally, so a single ordered table serves both
+// top-level and products[] fields (event-only keys simply never appear inside a product). Order =
+// warning order. Control fields (source/action/products/metadata) are intentionally omitted.
+static NSArray<NSArray *> *fieldTypeTable(void) {
+    static NSArray *table; static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        table = @[
+            @[BRAZE_PRODUCT_ID,      @(RudderBrazeFieldTypeString)],
+            @[BRAZE_PRODUCT_NAME,    @(RudderBrazeFieldTypeString)],
+            @[BRAZE_VARIANT_ID,      @(RudderBrazeFieldTypeString)],
+            @[BRAZE_QUANTITY,        @(RudderBrazeFieldTypeInteger)],
+            @[BRAZE_PRICE,           @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_IMAGE_URL,       @(RudderBrazeFieldTypeString)],
+            @[BRAZE_PRODUCT_URL,     @(RudderBrazeFieldTypeString)],
+            @[BRAZE_CART_ID,         @(RudderBrazeFieldTypeString)],
+            @[BRAZE_CHECKOUT_ID,     @(RudderBrazeFieldTypeString)],
+            @[BRAZE_ORDER_ID,        @(RudderBrazeFieldTypeString)],
+            @[BRAZE_CURRENCY,        @(RudderBrazeFieldTypeString)],
+            @[BRAZE_TOTAL_VALUE,     @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_SUBTOTAL_VALUE,  @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_TAX,             @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_SHIPPING,        @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_TOTAL_DISCOUNTS, @(RudderBrazeFieldTypeFloat)],
+            @[BRAZE_CANCEL_REASON,   @(RudderBrazeFieldTypeString)],
+            @[BRAZE_TYPE,            @(RudderBrazeFieldTypeStringArray)],
+            @[BRAZE_DISCOUNTS,       @(RudderBrazeFieldTypeArray)],
+        ];
+    });
+    return table;
+}
+
+// Coerces each resolved field toward its expected type (top-level and products[]), then logs one
+// warning listing any field whose value still does not match after coercion (sent as-is).
+static void coerceAndWarnTypes(NSString *brazeEvent, NSMutableDictionary *out) {
+    NSMutableArray<NSString *> *mismatched = [NSMutableArray array];
+    NSArray<NSArray *> *table = fieldTypeTable();
+
+    for (NSArray *entry in table) {
+        NSString *field = entry[0];
+        RudderBrazeFieldType type = (RudderBrazeFieldType)[entry[1] integerValue];
+        id value = out[field];
+        if (value != nil) {
+            id coerced = coerceValue(value, type);
+            out[field] = coerced;
+            if (!valueMatchesType(coerced, type)) {
+                [mismatched addObject:[NSString stringWithFormat:@"%@ (expected %@)", field, fieldTypeName(type)]];
+            }
+        }
+    }
+
+    id productsObj = out[BRAZE_PRODUCTS];
+    if ([productsObj isKindOfClass:[NSArray class]]) {
+        NSArray *products = (NSArray *)productsObj;
+        for (NSArray *entry in table) {
+            NSString *field = entry[0];
+            RudderBrazeFieldType type = (RudderBrazeFieldType)[entry[1] integerValue];
+            BOOL anyMismatch = NO;
+            for (id item in products) {
+                if ([item isKindOfClass:[NSMutableDictionary class]]) {
+                    NSMutableDictionary *product = (NSMutableDictionary *)item;
+                    id value = product[field];
+                    if (value != nil) {
+                        id coerced = coerceValue(value, type);
+                        product[field] = coerced;
+                        if (!valueMatchesType(coerced, type)) {
+                            anyMismatch = YES;
+                        }
+                    }
+                }
+            }
+            if (anyMismatch) {
+                [mismatched addObject:[NSString stringWithFormat:@"products[].%@ (expected %@)", field, fieldTypeName(type)]];
+            }
+        }
+    }
+
+    if (mismatched.count > 0) {
+        [RSLogger logWarn:[NSString stringWithFormat:
+            @"RudderBrazeIntegration: recommended event %@ has type-mismatched field(s) (sent as-is): [%@]",
+            brazeEvent, [mismatched componentsJoinedByString:@", "]]];
+    }
+}
+
+// numeric string -> number (FLOAT/INTEGER), number/boolean -> string (STRING). Numbers are left as-is
+// for numeric fields (Braze accepts an integer where a float is expected); arrays/objects are never
+// coerced. Anything that cannot be coerced is returned unchanged.
+static id coerceValue(id value, RudderBrazeFieldType type) {
+    switch (type) {
+        case RudderBrazeFieldTypeString:
+            if ([value isKindOfClass:[NSNumber class]]) {
+                return numberToBrazeString((NSNumber *)value);
+            }
+            return value;
+        case RudderBrazeFieldTypeFloat:
+            if ([value isKindOfClass:[NSString class]]) {
+                NSNumber *parsed = parseDoubleOrNil((NSString *)value);
+                return parsed != nil ? parsed : value;
+            }
+            return value;
+        case RudderBrazeFieldTypeInteger:
+            if ([value isKindOfClass:[NSString class]]) {
+                NSNumber *parsed = parseLongOrNil((NSString *)value);
+                return parsed != nil ? parsed : value;
+            }
+            return value;
+        case RudderBrazeFieldTypeStringArray:
+        case RudderBrazeFieldTypeArray:
+        default:
+            return value;
+    }
+}
+
+// 0 / false are valid; a numeric written as a string (e.g. "29.99") does not match a numeric type.
+static BOOL valueMatchesType(id value, RudderBrazeFieldType type) {
+    switch (type) {
+        case RudderBrazeFieldTypeString:
+            return [value isKindOfClass:[NSString class]];
+        case RudderBrazeFieldTypeInteger:
+            return [value isKindOfClass:[NSNumber class]] && !isBooleanNumber((NSNumber *)value)
+                && isIntegralNumber((NSNumber *)value);
+        case RudderBrazeFieldTypeFloat:
+            return [value isKindOfClass:[NSNumber class]] && !isBooleanNumber((NSNumber *)value);
+        case RudderBrazeFieldTypeStringArray:
+            return isStringArray(value);
+        case RudderBrazeFieldTypeArray:
+            return [value isKindOfClass:[NSArray class]];
+        default:
+            return YES;
+    }
+}
+
+static BOOL isIntegralNumber(NSNumber *number) {
+    const char *t = [number objCType];
+    if (strcmp(t, @encode(double)) == 0 || strcmp(t, @encode(float)) == 0) {
+        double d = [number doubleValue];
+        return isfinite(d) && d == floor(d);
+    }
+    return YES;
+}
+
+static BOOL isStringArray(id value) {
+    if (![value isKindOfClass:[NSArray class]]) {
+        return NO;
+    }
+    for (id item in (NSArray *)value) {
+        if (![item isKindOfClass:[NSString class]]) {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+static BOOL isBooleanNumber(NSNumber *number) {
+    return CFGetTypeID((__bridge CFTypeRef)number) == CFBooleanGetTypeID();
+}
+
+static NSString *numberToBrazeString(NSNumber *number) {
+    if (isBooleanNumber(number)) {
+        return [number boolValue] ? @"true" : @"false";
+    }
+    return [number stringValue];
+}
+
+static NSString *fieldTypeName(RudderBrazeFieldType type) {
+    switch (type) {
+        case RudderBrazeFieldTypeString:      return @"STRING";
+        case RudderBrazeFieldTypeInteger:     return @"INTEGER";
+        case RudderBrazeFieldTypeFloat:       return @"FLOAT";
+        case RudderBrazeFieldTypeStringArray: return @"STRING_ARRAY";
+        case RudderBrazeFieldTypeArray:       return @"ARRAY";
+    }
+    return @"";
+}
+
+// Parses a fully-numeric string to a double, or nil if it is not a valid number (then sent as-is).
+static NSNumber *parseDoubleOrNil(NSString *string) {
+    NSString *trimmed = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (trimmed.length == 0) {
+        return nil;
+    }
+    const char *c = [trimmed UTF8String];
+    char *end = NULL;
+    double d = strtod(c, &end);
+    if (end == c || *end != '\0') {
+        return nil;
+    }
+    return @(d);
+}
+
+// Parses a fully-integral string to a long, or nil otherwise (e.g. "2.5" and "free" both fail).
+static NSNumber *parseLongOrNil(NSString *string) {
+    NSString *trimmed = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    if (trimmed.length == 0) {
+        return nil;
+    }
+    const char *c = [trimmed UTF8String];
+    char *end = NULL;
+    long long v = strtoll(c, &end, 10);
+    if (end == c || *end != '\0') {
+        return nil;
+    }
+    return @(v);
 }
 
 @end

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -43,7 +43,6 @@ typedef NS_ENUM(NSInteger, RudderBrazeEcommerceEventType) {
 
 #pragma mark - Constants
 
-// Braze recommended ecommerce event names (destination side).
 static NSString *const BRAZE_EVENT_PRODUCT_VIEWED = @"ecommerce.product_viewed";
 static NSString *const BRAZE_EVENT_CART_UPDATED = @"ecommerce.cart_updated";
 static NSString *const BRAZE_EVENT_CHECKOUT_STARTED = @"ecommerce.checkout_started";
@@ -51,16 +50,13 @@ static NSString *const BRAZE_EVENT_ORDER_PLACED = @"ecommerce.order_placed";
 static NSString *const BRAZE_EVENT_ORDER_REFUNDED = @"ecommerce.order_refunded";
 static NSString *const BRAZE_EVENT_ORDER_CANCELLED = @"ecommerce.order_cancelled";
 
-// cart_updated actions.
 static NSString *const ACTION_ADD = @"add";
 static NSString *const ACTION_REMOVE = @"remove";
 
-// source is hardcoded per platform for mobile device mode (no channel derivation).
 static NSString *const SOURCE_KEY = @"source";
 static NSString *const SOURCE = @"ios";
 
-// RudderStack ecommerce source keys. Hardcoded as literals to match the existing integration's
-// style (see getPurchaseList); these correspond to the RS ecommerce spec field names.
+// RudderStack ecommerce source keys.
 static NSString *const EC_PRODUCT_ID = @"product_id";
 static NSString *const EC_QUANTITY = @"quantity";
 static NSString *const EC_PRICE = @"price";
@@ -84,11 +80,10 @@ static NSString *const EC_TYPE = @"type";
 static NSString *const EC_SUBTOTAL_VALUE = @"subtotal_value";
 static NSString *const EC_DISCOUNTS = @"discounts";
 static NSString *const EC_TOTAL_DISCOUNTS = @"total_discounts";
-// cancel_reason / reason are both valid RS sources for Braze's required cancel_reason.
 static NSString *const EC_CANCEL_REASON = @"cancel_reason";
 static NSString *const EC_REASON = @"reason";
 
-// Braze recommended-event field names (official Braze schema names).
+// Braze recommended-event field names.
 static NSString *const BRAZE_PRODUCT_ID = @"product_id";
 static NSString *const BRAZE_PRODUCT_NAME = @"product_name";
 static NSString *const BRAZE_VARIANT_ID = @"variant_id";
@@ -114,10 +109,9 @@ static NSString *const BRAZE_METADATA = @"metadata";
 
 @implementation RudderBrazeEcommerceUtils
 
-#pragma mark - Consumed-key sets (D6 metadata pass-through)
+#pragma mark - Consumed-key sets
 
-// Any RS source key NOT consumed by a top-level / product mapping flows into metadata /
-// products[].metadata, never left top-level.
+// Source keys consumed by each event's mapping; everything else flows into metadata.
 + (NSSet<NSString *> *)productConsumedKeys {
     static NSSet *keys; static dispatch_once_t t;
     dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL]]; });
@@ -165,7 +159,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
 + (NSDictionary<NSString *, RudderBrazeEcommerceEvent *> *)ecommerceEventMapping {
     static NSDictionary *mapping; static dispatch_once_t t;
     dispatch_once(&t, ^{
-        // Keys are the RudderStack ecommerce event names, lowercased for case-insensitive lookup.
         mapping = @{
             @"product viewed":    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductViewed brazeEvent:BRAZE_EVENT_PRODUCT_VIEWED action:nil],
             @"product added":     [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductAdded brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_ADD],
@@ -210,7 +203,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return [NSMutableDictionary dictionary];
 }
 
-// ecommerce.product_viewed - flat, single-product event (no products array, no quantity).
 + (NSDictionary<NSString *, id> *)buildProductViewed:(NSDictionary *)props {
     NSString *brazeEvent = BRAZE_EVENT_PRODUCT_VIEWED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -241,8 +233,8 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return out;
 }
 
-// ecommerce.cart_updated - Product Added/Removed; single top-level product wrapped into a
-// 1-element products array. action is the only difference between add and remove.
+// A single top-level product is wrapped into a 1-element products array; action distinguishes
+// add from remove.
 + (NSDictionary<NSString *, id> *)buildCartUpdated:(NSDictionary *)props action:(NSString *)action {
     NSString *brazeEvent = BRAZE_EVENT_CART_UPDATED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -273,7 +265,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return out;
 }
 
-// ecommerce.checkout_started - checkout_id falls back to order_id.
 + (NSDictionary<NSString *, id> *)buildCheckoutStarted:(NSDictionary *)props {
     NSString *brazeEvent = BRAZE_EVENT_CHECKOUT_STARTED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -306,8 +297,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return out;
 }
 
-// ecommerce.order_placed - Order Completed. One event per order with all products inside
-// products[] (vs. the legacy one-purchase-per-product model).
 + (NSDictionary<NSString *, id> *)buildOrderPlaced:(NSDictionary *)props {
     NSString *brazeEvent = BRAZE_EVENT_ORDER_PLACED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -342,8 +331,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return out;
 }
 
-// ecommerce.order_refunded - RS Order Refunded carries only order_id today; total_value,
-// currency and products are RS-spec gaps (mapped if present, warned if absent).
 + (NSDictionary<NSString *, id> *)buildOrderRefunded:(NSDictionary *)props {
     NSString *brazeEvent = BRAZE_EVENT_ORDER_REFUNDED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -374,8 +361,6 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return out;
 }
 
-// ecommerce.order_cancelled - cancel_reason falls back to the standard RS reason field
-// (mapped if present, warned if absent). total_value kept verbatim (no abs).
 + (NSDictionary<NSString *, id> *)buildOrderCancelled:(NSDictionary *)props {
     NSString *brazeEvent = BRAZE_EVENT_ORDER_CANCELLED;
     NSMutableDictionary *out = [NSMutableDictionary dictionary];
@@ -434,9 +419,7 @@ static NSString *const BRAZE_METADATA = @"metadata";
     return product;
 }
 
-// Maps the shared Braze product object (no metadata). cart_updated routes leftover product keys
-// into event-level metadata, so it uses this directly; array products add per-product metadata
-// via buildProduct.
+// Maps the shared Braze product object without metadata; callers add metadata as needed.
 + (NSMutableDictionary *)buildProductFields:(NSDictionary *)rsProduct {
     NSMutableDictionary *product = [NSMutableDictionary dictionary];
     putIfPresent(product, BRAZE_PRODUCT_ID, firstNonNull(rsProduct, @[EC_PRODUCT_ID, EC_SKU]));
@@ -451,7 +434,7 @@ static NSString *const BRAZE_METADATA = @"metadata";
 
 #pragma mark - Helpers
 
-// D6: any source key not consumed by a mapping flows into metadata (never left top-level).
+// Copies every key not consumed by the mapping into a nested metadata object.
 static void putMetadata(NSMutableDictionary *target, NSDictionary *props, NSSet<NSString *> *consumedKeys) {
     NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
     for (NSString *key in props) {
@@ -467,7 +450,7 @@ static void putMetadata(NSMutableDictionary *target, NSDictionary *props, NSSet<
     }
 }
 
-// Returns the first non-null, non-empty value among the given keys (fallback chain).
+// First non-null, non-empty value among the given keys.
 static id firstNonNull(NSDictionary *props, NSArray<NSString *> *keys) {
     if (props == nil) {
         return nil;
@@ -488,8 +471,7 @@ static void putIfPresent(NSMutableDictionary *target, NSString *key, id value) {
     }
 }
 
-// Send-anyway validation (D5): a missing Braze-required field is logged but never drops the event.
-// source is intentionally never checked here - it always resolves to the platform.
+// Logs a missing required field without dropping the event.
 static void warnIfMissing(NSString *brazeEvent, NSString *field, id value) {
     if (value == nil) {
         [RSLogger logWarn:[NSString stringWithFormat:

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -1,0 +1,501 @@
+//
+//  RudderBrazeEcommerceUtils.m
+//
+
+#import "RudderBrazeEcommerceUtils.h"
+
+#if defined(__has_include) && __has_include(<Rudder/Rudder.h>)
+#import <Rudder/Rudder.h>
+#else
+#import "Rudder.h"
+#endif
+
+#pragma mark - Event type
+
+typedef NS_ENUM(NSInteger, RudderBrazeEcommerceEventType) {
+    RudderBrazeEcommerceEventTypeProductViewed,
+    RudderBrazeEcommerceEventTypeProductAdded,
+    RudderBrazeEcommerceEventTypeProductRemoved,
+    RudderBrazeEcommerceEventTypeCheckoutStarted,
+    RudderBrazeEcommerceEventTypeOrderCompleted,
+    RudderBrazeEcommerceEventTypeOrderRefunded,
+    RudderBrazeEcommerceEventTypeOrderCancelled
+};
+
+@interface RudderBrazeEcommerceEvent ()
+@property (nonatomic, assign) RudderBrazeEcommerceEventType type;
+@property (nonatomic, copy) NSString *brazeEvent;
+@property (nonatomic, copy, nullable) NSString *action;
++ (instancetype)eventWithType:(RudderBrazeEcommerceEventType)type brazeEvent:(NSString *)brazeEvent action:(nullable NSString *)action;
+@end
+
+@implementation RudderBrazeEcommerceEvent
+
++ (instancetype)eventWithType:(RudderBrazeEcommerceEventType)type brazeEvent:(NSString *)brazeEvent action:(NSString *)action {
+    RudderBrazeEcommerceEvent *event = [[RudderBrazeEcommerceEvent alloc] init];
+    event.type = type;
+    event.brazeEvent = brazeEvent;
+    event.action = action;
+    return event;
+}
+
+@end
+
+#pragma mark - Constants
+
+// Braze recommended ecommerce event names (destination side).
+static NSString *const BRAZE_EVENT_PRODUCT_VIEWED = @"ecommerce.product_viewed";
+static NSString *const BRAZE_EVENT_CART_UPDATED = @"ecommerce.cart_updated";
+static NSString *const BRAZE_EVENT_CHECKOUT_STARTED = @"ecommerce.checkout_started";
+static NSString *const BRAZE_EVENT_ORDER_PLACED = @"ecommerce.order_placed";
+static NSString *const BRAZE_EVENT_ORDER_REFUNDED = @"ecommerce.order_refunded";
+static NSString *const BRAZE_EVENT_ORDER_CANCELLED = @"ecommerce.order_cancelled";
+
+// cart_updated actions.
+static NSString *const ACTION_ADD = @"add";
+static NSString *const ACTION_REMOVE = @"remove";
+
+// source is hardcoded per platform for mobile device mode (no channel derivation).
+static NSString *const SOURCE_KEY = @"source";
+static NSString *const SOURCE = @"ios";
+
+// RudderStack ecommerce source keys. Hardcoded as literals to match the existing integration's
+// style (see getPurchaseList); these correspond to the RS ecommerce spec field names.
+static NSString *const EC_PRODUCT_ID = @"product_id";
+static NSString *const EC_QUANTITY = @"quantity";
+static NSString *const EC_PRICE = @"price";
+static NSString *const EC_CURRENCY = @"currency";
+static NSString *const EC_PRODUCTS = @"products";
+static NSString *const EC_CART_ID = @"cart_id";
+static NSString *const EC_CHECKOUT_ID = @"checkout_id";
+static NSString *const EC_ORDER_ID = @"order_id";
+static NSString *const EC_TOTAL = @"total";
+static NSString *const EC_REVENUE = @"revenue";
+static NSString *const EC_DISCOUNT = @"discount";
+static NSString *const EC_SKU = @"sku";
+static NSString *const EC_NAME = @"name";
+static NSString *const EC_VARIANT = @"variant";
+static NSString *const EC_IMAGE_URL = @"image_url";
+static NSString *const EC_URL = @"url";
+static NSString *const EC_VALUE = @"value";
+static NSString *const EC_TAX = @"tax";
+static NSString *const EC_SHIPPING = @"shipping";
+static NSString *const EC_TYPE = @"type";
+static NSString *const EC_SUBTOTAL_VALUE = @"subtotal_value";
+static NSString *const EC_DISCOUNTS = @"discounts";
+static NSString *const EC_TOTAL_DISCOUNTS = @"total_discounts";
+// cancel_reason / reason are both valid RS sources for Braze's required cancel_reason.
+static NSString *const EC_CANCEL_REASON = @"cancel_reason";
+static NSString *const EC_REASON = @"reason";
+
+// Braze recommended-event field names (official Braze schema names).
+static NSString *const BRAZE_PRODUCT_ID = @"product_id";
+static NSString *const BRAZE_PRODUCT_NAME = @"product_name";
+static NSString *const BRAZE_VARIANT_ID = @"variant_id";
+static NSString *const BRAZE_QUANTITY = @"quantity";
+static NSString *const BRAZE_PRICE = @"price";
+static NSString *const BRAZE_IMAGE_URL = @"image_url";
+static NSString *const BRAZE_PRODUCT_URL = @"product_url";
+static NSString *const BRAZE_CART_ID = @"cart_id";
+static NSString *const BRAZE_ACTION = @"action";
+static NSString *const BRAZE_ORDER_ID = @"order_id";
+static NSString *const BRAZE_CHECKOUT_ID = @"checkout_id";
+static NSString *const BRAZE_TOTAL_VALUE = @"total_value";
+static NSString *const BRAZE_CURRENCY = @"currency";
+static NSString *const BRAZE_PRODUCTS = @"products";
+static NSString *const BRAZE_TAX = @"tax";
+static NSString *const BRAZE_SHIPPING = @"shipping";
+static NSString *const BRAZE_TOTAL_DISCOUNTS = @"total_discounts";
+static NSString *const BRAZE_CANCEL_REASON = @"cancel_reason";
+static NSString *const BRAZE_TYPE = @"type";
+static NSString *const BRAZE_SUBTOTAL_VALUE = @"subtotal_value";
+static NSString *const BRAZE_DISCOUNTS = @"discounts";
+static NSString *const BRAZE_METADATA = @"metadata";
+
+@implementation RudderBrazeEcommerceUtils
+
+#pragma mark - Consumed-key sets (D6 metadata pass-through)
+
+// Any RS source key NOT consumed by a top-level / product mapping flows into metadata /
+// products[].metadata, never left top-level.
++ (NSSet<NSString *> *)productConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)productViewedConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_PRICE, EC_CURRENCY, EC_IMAGE_URL, EC_URL, EC_TYPE]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)cartUpdatedConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_CART_ID, EC_CURRENCY, EC_PRODUCT_ID, EC_SKU, EC_NAME, EC_VARIANT, EC_QUANTITY, EC_PRICE, EC_IMAGE_URL, EC_URL, EC_TOTAL, EC_VALUE, EC_SUBTOTAL_VALUE, EC_TAX, EC_SHIPPING]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)checkoutStartedConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_CHECKOUT_ID, EC_ORDER_ID, EC_CART_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)orderPlacedConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_ORDER_ID, EC_CART_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)orderRefundedConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_CURRENCY, EC_PRODUCTS, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS]]; });
+    return keys;
+}
+
++ (NSSet<NSString *> *)orderCancelledConsumedKeys {
+    static NSSet *keys; static dispatch_once_t t;
+    dispatch_once(&t, ^{ keys = [NSSet setWithArray:@[EC_ORDER_ID, EC_TOTAL, EC_REVENUE, EC_VALUE, EC_SUBTOTAL_VALUE, EC_CURRENCY, EC_CANCEL_REASON, EC_REASON, EC_PRODUCTS, EC_TAX, EC_SHIPPING, EC_DISCOUNT, EC_TOTAL_DISCOUNTS, EC_DISCOUNTS]]; });
+    return keys;
+}
+
+#pragma mark - Resolution
+
++ (NSDictionary<NSString *, RudderBrazeEcommerceEvent *> *)ecommerceEventMapping {
+    static NSDictionary *mapping; static dispatch_once_t t;
+    dispatch_once(&t, ^{
+        // Keys are the RudderStack ecommerce event names, lowercased for case-insensitive lookup.
+        mapping = @{
+            @"product viewed":    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductViewed brazeEvent:BRAZE_EVENT_PRODUCT_VIEWED action:nil],
+            @"product added":     [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductAdded brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_ADD],
+            @"product removed":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeProductRemoved brazeEvent:BRAZE_EVENT_CART_UPDATED action:ACTION_REMOVE],
+            @"checkout started":  [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeCheckoutStarted brazeEvent:BRAZE_EVENT_CHECKOUT_STARTED action:nil],
+            @"order completed":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCompleted brazeEvent:BRAZE_EVENT_ORDER_PLACED action:nil],
+            @"order refunded":    [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderRefunded brazeEvent:BRAZE_EVENT_ORDER_REFUNDED action:nil],
+            @"order cancelled":   [RudderBrazeEcommerceEvent eventWithType:RudderBrazeEcommerceEventTypeOrderCancelled brazeEvent:BRAZE_EVENT_ORDER_CANCELLED action:nil],
+        };
+    });
+    return mapping;
+}
+
++ (RudderBrazeEcommerceEvent *)resolveEcommerceEvent:(NSString *)eventName {
+    if (![eventName isKindOfClass:[NSString class]]) {
+        return nil;
+    }
+    NSString *key = [[eventName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] lowercaseString];
+    return [self ecommerceEventMapping][key];
+}
+
+#pragma mark - Building
+
++ (NSDictionary<NSString *, id> *)buildEcommerceProperties:(RudderBrazeEcommerceEvent *)ecommerceEvent
+                                                properties:(NSDictionary<NSString *, id> *)properties {
+    NSDictionary *props = (properties != nil) ? properties : @{};
+    switch (ecommerceEvent.type) {
+        case RudderBrazeEcommerceEventTypeProductViewed:
+            return [self buildProductViewed:props];
+        case RudderBrazeEcommerceEventTypeProductAdded:
+        case RudderBrazeEcommerceEventTypeProductRemoved:
+            return [self buildCartUpdated:props action:ecommerceEvent.action];
+        case RudderBrazeEcommerceEventTypeCheckoutStarted:
+            return [self buildCheckoutStarted:props];
+        case RudderBrazeEcommerceEventTypeOrderCompleted:
+            return [self buildOrderPlaced:props];
+        case RudderBrazeEcommerceEventTypeOrderRefunded:
+            return [self buildOrderRefunded:props];
+        case RudderBrazeEcommerceEventTypeOrderCancelled:
+            return [self buildOrderCancelled:props];
+    }
+    return [NSMutableDictionary dictionary];
+}
+
+// ecommerce.product_viewed - flat, single-product event (no products array, no quantity).
++ (NSDictionary<NSString *, id> *)buildProductViewed:(NSDictionary *)props {
+    NSString *brazeEvent = BRAZE_EVENT_PRODUCT_VIEWED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id productId = firstNonNull(props, @[EC_PRODUCT_ID, EC_SKU]);
+    id productName = firstNonNull(props, @[EC_NAME]);
+    id variantId = firstNonNull(props, @[EC_VARIANT, EC_SKU, EC_PRODUCT_ID]);
+    id price = firstNonNull(props, @[EC_PRICE]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+
+    warnIfMissing(brazeEvent, BRAZE_PRODUCT_ID, productId);
+    warnIfMissing(brazeEvent, BRAZE_PRODUCT_NAME, productName);
+    warnIfMissing(brazeEvent, BRAZE_VARIANT_ID, variantId);
+    warnIfMissing(brazeEvent, BRAZE_PRICE, price);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+
+    putIfPresent(out, BRAZE_PRODUCT_ID, productId);
+    putIfPresent(out, BRAZE_PRODUCT_NAME, productName);
+    putIfPresent(out, BRAZE_VARIANT_ID, variantId);
+    putIfPresent(out, BRAZE_PRICE, price);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    putIfPresent(out, BRAZE_IMAGE_URL, firstNonNull(props, @[EC_IMAGE_URL]));
+    putIfPresent(out, BRAZE_PRODUCT_URL, firstNonNull(props, @[EC_URL]));
+    putIfPresent(out, BRAZE_TYPE, firstNonNull(props, @[EC_TYPE]));
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self productViewedConsumedKeys]);
+    return out;
+}
+
+// ecommerce.cart_updated - Product Added/Removed; single top-level product wrapped into a
+// 1-element products array. action is the only difference between add and remove.
++ (NSDictionary<NSString *, id> *)buildCartUpdated:(NSDictionary *)props action:(NSString *)action {
+    NSString *brazeEvent = BRAZE_EVENT_CART_UPDATED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id cartId = firstNonNull(props, @[EC_CART_ID]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+    NSMutableDictionary *product = [self buildProductFields:props];
+
+    warnIfMissing(brazeEvent, BRAZE_CART_ID, cartId);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+    if (product.count == 0) {
+        warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
+    }
+
+    putIfPresent(out, BRAZE_CART_ID, cartId);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    putIfPresent(out, BRAZE_TOTAL_VALUE, firstNonNull(props, @[EC_TOTAL, EC_VALUE]));
+    putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, @[EC_SUBTOTAL_VALUE]));
+    putIfPresent(out, BRAZE_TAX, firstNonNull(props, @[EC_TAX]));
+    putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
+    out[BRAZE_ACTION] = action;
+    if (product.count > 0) {
+        out[BRAZE_PRODUCTS] = @[product];
+    }
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self cartUpdatedConsumedKeys]);
+    return out;
+}
+
+// ecommerce.checkout_started - checkout_id falls back to order_id.
++ (NSDictionary<NSString *, id> *)buildCheckoutStarted:(NSDictionary *)props {
+    NSString *brazeEvent = BRAZE_EVENT_CHECKOUT_STARTED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id checkoutId = firstNonNull(props, @[EC_CHECKOUT_ID, EC_ORDER_ID]);
+    id totalValue = firstNonNull(props, @[EC_TOTAL, EC_REVENUE, EC_VALUE]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+    NSArray *products = [self buildProducts:props];
+
+    warnIfMissing(brazeEvent, BRAZE_CHECKOUT_ID, checkoutId);
+    warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+    if (products == nil) {
+        warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
+    }
+
+    putIfPresent(out, BRAZE_CHECKOUT_ID, checkoutId);
+    putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    if (products != nil) {
+        out[BRAZE_PRODUCTS] = products;
+    }
+    putIfPresent(out, BRAZE_CART_ID, firstNonNull(props, @[EC_CART_ID]));
+    putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, @[EC_SUBTOTAL_VALUE]));
+    putIfPresent(out, BRAZE_TAX, firstNonNull(props, @[EC_TAX]));
+    putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self checkoutStartedConsumedKeys]);
+    return out;
+}
+
+// ecommerce.order_placed - Order Completed. One event per order with all products inside
+// products[] (vs. the legacy one-purchase-per-product model).
++ (NSDictionary<NSString *, id> *)buildOrderPlaced:(NSDictionary *)props {
+    NSString *brazeEvent = BRAZE_EVENT_ORDER_PLACED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id orderId = firstNonNull(props, @[EC_ORDER_ID]);
+    id totalValue = firstNonNull(props, @[EC_TOTAL, EC_REVENUE, EC_VALUE]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+    NSArray *products = [self buildProducts:props];
+
+    warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+    warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+    if (products == nil) {
+        warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
+    }
+
+    putIfPresent(out, BRAZE_ORDER_ID, orderId);
+    putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    if (products != nil) {
+        out[BRAZE_PRODUCTS] = products;
+    }
+    putIfPresent(out, BRAZE_CART_ID, firstNonNull(props, @[EC_CART_ID]));
+    putIfPresent(out, BRAZE_TAX, firstNonNull(props, @[EC_TAX]));
+    putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
+    putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNT, EC_TOTAL_DISCOUNTS]));
+    putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, @[EC_SUBTOTAL_VALUE]));
+    putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self orderPlacedConsumedKeys]);
+    return out;
+}
+
+// ecommerce.order_refunded - RS Order Refunded carries only order_id today; total_value,
+// currency and products are RS-spec gaps (mapped if present, warned if absent).
++ (NSDictionary<NSString *, id> *)buildOrderRefunded:(NSDictionary *)props {
+    NSString *brazeEvent = BRAZE_EVENT_ORDER_REFUNDED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id orderId = firstNonNull(props, @[EC_ORDER_ID]);
+    id totalValue = firstNonNull(props, @[EC_TOTAL, EC_REVENUE, EC_VALUE]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+    NSArray *products = [self buildProducts:props];
+
+    warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+    warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+    if (products == nil) {
+        warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
+    }
+
+    putIfPresent(out, BRAZE_ORDER_ID, orderId);
+    putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    if (products != nil) {
+        out[BRAZE_PRODUCTS] = products;
+    }
+    putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNT, EC_TOTAL_DISCOUNTS]));
+    putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self orderRefundedConsumedKeys]);
+    return out;
+}
+
+// ecommerce.order_cancelled - cancel_reason falls back to the standard RS reason field
+// (mapped if present, warned if absent). total_value kept verbatim (no abs).
++ (NSDictionary<NSString *, id> *)buildOrderCancelled:(NSDictionary *)props {
+    NSString *brazeEvent = BRAZE_EVENT_ORDER_CANCELLED;
+    NSMutableDictionary *out = [NSMutableDictionary dictionary];
+
+    id orderId = firstNonNull(props, @[EC_ORDER_ID]);
+    id totalValue = firstNonNull(props, @[EC_TOTAL, EC_REVENUE, EC_VALUE]);
+    id currency = firstNonNull(props, @[EC_CURRENCY]);
+    id cancelReason = firstNonNull(props, @[EC_CANCEL_REASON, EC_REASON]);
+    NSArray *products = [self buildProducts:props];
+
+    warnIfMissing(brazeEvent, BRAZE_ORDER_ID, orderId);
+    warnIfMissing(brazeEvent, BRAZE_TOTAL_VALUE, totalValue);
+    warnIfMissing(brazeEvent, BRAZE_CURRENCY, currency);
+    warnIfMissing(brazeEvent, BRAZE_CANCEL_REASON, cancelReason);
+    if (products == nil) {
+        warnIfMissing(brazeEvent, BRAZE_PRODUCTS, nil);
+    }
+
+    putIfPresent(out, BRAZE_ORDER_ID, orderId);
+    putIfPresent(out, BRAZE_TOTAL_VALUE, totalValue);
+    putIfPresent(out, BRAZE_CURRENCY, currency);
+    putIfPresent(out, BRAZE_CANCEL_REASON, cancelReason);
+    if (products != nil) {
+        out[BRAZE_PRODUCTS] = products;
+    }
+    putIfPresent(out, BRAZE_TAX, firstNonNull(props, @[EC_TAX]));
+    putIfPresent(out, BRAZE_SHIPPING, firstNonNull(props, @[EC_SHIPPING]));
+    putIfPresent(out, BRAZE_TOTAL_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNT, EC_TOTAL_DISCOUNTS]));
+    putIfPresent(out, BRAZE_SUBTOTAL_VALUE, firstNonNull(props, @[EC_SUBTOTAL_VALUE]));
+    putIfPresent(out, BRAZE_DISCOUNTS, firstNonNull(props, @[EC_DISCOUNTS]));
+    out[SOURCE_KEY] = SOURCE;
+
+    putMetadata(out, props, [self orderCancelledConsumedKeys]);
+    return out;
+}
+
+#pragma mark - Products
+
++ (nullable NSArray<NSDictionary *> *)buildProducts:(NSDictionary *)props {
+    id raw = props[EC_PRODUCTS];
+    if (![raw isKindOfClass:[NSArray class]]) {
+        return nil;
+    }
+    NSMutableArray *products = [NSMutableArray array];
+    for (id item in (NSArray *)raw) {
+        if ([item isKindOfClass:[NSDictionary class]]) {
+            [products addObject:[self buildProduct:(NSDictionary *)item]];
+        }
+    }
+    return products.count > 0 ? products : nil;
+}
+
++ (NSMutableDictionary *)buildProduct:(NSDictionary *)rsProduct {
+    NSMutableDictionary *product = [self buildProductFields:rsProduct];
+    putMetadata(product, rsProduct, [self productConsumedKeys]);
+    return product;
+}
+
+// Maps the shared Braze product object (no metadata). cart_updated routes leftover product keys
+// into event-level metadata, so it uses this directly; array products add per-product metadata
+// via buildProduct.
++ (NSMutableDictionary *)buildProductFields:(NSDictionary *)rsProduct {
+    NSMutableDictionary *product = [NSMutableDictionary dictionary];
+    putIfPresent(product, BRAZE_PRODUCT_ID, firstNonNull(rsProduct, @[EC_PRODUCT_ID, EC_SKU]));
+    putIfPresent(product, BRAZE_PRODUCT_NAME, firstNonNull(rsProduct, @[EC_NAME]));
+    putIfPresent(product, BRAZE_VARIANT_ID, firstNonNull(rsProduct, @[EC_VARIANT, EC_SKU, EC_PRODUCT_ID]));
+    putIfPresent(product, BRAZE_QUANTITY, firstNonNull(rsProduct, @[EC_QUANTITY]));
+    putIfPresent(product, BRAZE_PRICE, firstNonNull(rsProduct, @[EC_PRICE]));
+    putIfPresent(product, BRAZE_IMAGE_URL, firstNonNull(rsProduct, @[EC_IMAGE_URL]));
+    putIfPresent(product, BRAZE_PRODUCT_URL, firstNonNull(rsProduct, @[EC_URL]));
+    return product;
+}
+
+#pragma mark - Helpers
+
+// D6: any source key not consumed by a mapping flows into metadata (never left top-level).
+static void putMetadata(NSMutableDictionary *target, NSDictionary *props, NSSet<NSString *> *consumedKeys) {
+    NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
+    for (NSString *key in props) {
+        if (![consumedKeys containsObject:key]) {
+            id value = props[key];
+            if (value != nil) {
+                metadata[key] = value;
+            }
+        }
+    }
+    if (metadata.count > 0) {
+        target[BRAZE_METADATA] = metadata;
+    }
+}
+
+// Returns the first non-null, non-empty value among the given keys (fallback chain).
+static id firstNonNull(NSDictionary *props, NSArray<NSString *> *keys) {
+    if (props == nil) {
+        return nil;
+    }
+    for (NSString *key in keys) {
+        id value = props[key];
+        if (value != nil && value != [NSNull null] &&
+            !([value isKindOfClass:[NSString class]] && [(NSString *)value length] == 0)) {
+            return value;
+        }
+    }
+    return nil;
+}
+
+static void putIfPresent(NSMutableDictionary *target, NSString *key, id value) {
+    if (value != nil && value != [NSNull null]) {
+        target[key] = value;
+    }
+}
+
+// Send-anyway validation (D5): a missing Braze-required field is logged but never drops the event.
+// source is intentionally never checked here - it always resolves to the platform.
+static void warnIfMissing(NSString *brazeEvent, NSString *field, id value) {
+    if (value == nil) {
+        [RSLogger logWarn:[NSString stringWithFormat:
+            @"RudderBrazeIntegration: recommended event %@ is missing required field '%@'; sending event anyway.",
+            brazeEvent, field]];
+    }
+}
+
+@end

--- a/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
+++ b/Rudder-Braze/Classes/RudderBrazeEcommerceUtils.m
@@ -10,6 +10,11 @@
 #import "Rudder.h"
 #endif
 
+// Headers for the C library functions used below (strcmp / strtod / strtoll / isfinite / floor).
+#import <string.h>
+#import <stdlib.h>
+#import <math.h>
+
 #pragma mark - Event type
 
 typedef NS_ENUM(NSInteger, RudderBrazeEcommerceEventType) {
@@ -31,7 +36,7 @@ typedef NS_ENUM(NSInteger, RudderBrazeEcommerceEventType) {
 
 @implementation RudderBrazeEcommerceEvent
 
-+ (instancetype)eventWithType:(RudderBrazeEcommerceEventType)type brazeEvent:(NSString *)brazeEvent action:(NSString *)action {
++ (instancetype)eventWithType:(RudderBrazeEcommerceEventType)type brazeEvent:(NSString *)brazeEvent action:(nullable NSString *)action {
     RudderBrazeEcommerceEvent *event = [[RudderBrazeEcommerceEvent alloc] init];
     event.type = type;
     event.brazeEvent = brazeEvent;
@@ -215,23 +220,23 @@ static NSNumber *parseLongOrNil(NSString *string);
     NSMutableDictionary *out = nil;
     switch (ecommerceEvent.type) {
         case RudderBrazeEcommerceEventTypeProductViewed:
-            out = (NSMutableDictionary *)[self buildProductViewed:props];
+            out = [[self buildProductViewed:props] mutableCopy];
             break;
         case RudderBrazeEcommerceEventTypeProductAdded:
         case RudderBrazeEcommerceEventTypeProductRemoved:
-            out = (NSMutableDictionary *)[self buildCartUpdated:props action:ecommerceEvent.action];
+            out = [[self buildCartUpdated:props action:ecommerceEvent.action] mutableCopy];
             break;
         case RudderBrazeEcommerceEventTypeCheckoutStarted:
-            out = (NSMutableDictionary *)[self buildCheckoutStarted:props];
+            out = [[self buildCheckoutStarted:props] mutableCopy];
             break;
         case RudderBrazeEcommerceEventTypeOrderCompleted:
-            out = (NSMutableDictionary *)[self buildOrderPlaced:props];
+            out = [[self buildOrderPlaced:props] mutableCopy];
             break;
         case RudderBrazeEcommerceEventTypeOrderRefunded:
-            out = (NSMutableDictionary *)[self buildOrderRefunded:props];
+            out = [[self buildOrderRefunded:props] mutableCopy];
             break;
         case RudderBrazeEcommerceEventTypeOrderCancelled:
-            out = (NSMutableDictionary *)[self buildOrderCancelled:props];
+            out = [[self buildOrderCancelled:props] mutableCopy];
             break;
     }
     if (out == nil) {
@@ -446,7 +451,12 @@ static NSNumber *parseLongOrNil(NSString *string);
     NSMutableArray *products = [NSMutableArray array];
     for (id item in (NSArray *)raw) {
         if ([item isKindOfClass:[NSDictionary class]]) {
-            [products addObject:[self buildProduct:(NSDictionary *)item]];
+            NSMutableDictionary *product = [self buildProduct:(NSDictionary *)item];
+            // Skip empty product maps so an all-empty products array is treated as "no products"
+            // (omitted + missing-field warning) rather than sending products: [ {} ].
+            if (product.count > 0) {
+                [products addObject:product];
+            }
         }
     }
     return products.count > 0 ? products : nil;
@@ -479,7 +489,7 @@ static void putMetadata(NSMutableDictionary *target, NSDictionary *props, NSSet<
     for (NSString *key in props) {
         if (![consumedKeys containsObject:key]) {
             id value = props[key];
-            if (value != nil) {
+            if (value != nil && value != [NSNull null]) {
                 metadata[key] = value;
             }
         }

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -38,6 +38,7 @@ typedef enum {
 @property (nonatomic, strong) NSDictionary *config;
 @property (nonatomic, strong) RSClient *client;
 @property (nonatomic) BOOL supportDedup;
+@property (nonatomic) BOOL useRecommendedEcommerceEvents;
 @property (nonatomic, strong) RSMessage *previousIdentifyElement;
 @property (nonatomic) NSString *prevExternalId;
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.h
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.h
@@ -38,7 +38,7 @@ typedef enum {
 @property (nonatomic, strong) NSDictionary *config;
 @property (nonatomic, strong) RSClient *client;
 @property (nonatomic) BOOL supportDedup;
-@property (nonatomic) BOOL useRecommendedEcommerceEvents;
+@property (nonatomic) BOOL useEcommerceRecommendedEvents;
 @property (nonatomic, strong) RSMessage *previousIdentifyElement;
 @property (nonatomic) NSString *prevExternalId;
 

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,8 +19,6 @@ static Braze *rsBrazeInstance;
         self.config = config;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
-        // Recommended ecommerce events flag (default off; on = hard cutover). Mapping logic lives
-        // in RudderBrazeEcommerceUtils.
         self.useRecommendedEcommerceEvents = [[config objectForKey:@"useRecommendedEcommerceEvents"] boolValue] ? YES : NO;
 
         BOOL usePlatformSpecificAppIdentifierKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
@@ -269,10 +267,8 @@ static Braze *rsBrazeInstance;
         }
         self.previousIdentifyElement = message;
     } else if([message.type isEqualToString:@"track"]) {
-        // When the flag is on, recommended ecommerce events take a hard cutover before the legacy
-        // Install Attributed / Order Completed paths. Events with no recommended-event counterpart
-        // (Product Clicked, Cart Viewed, Install Attributed, etc.) fall through and keep their
-        // existing behaviour.
+        // When enabled, recommended ecommerce events are handled before the legacy paths; other
+        // events fall through unchanged.
         if (self.useRecommendedEcommerceEvents) {
             RudderBrazeEcommerceEvent *ecommerceEvent = [RudderBrazeEcommerceUtils resolveEcommerceEvent:message.event];
             if (ecommerceEvent != nil) {

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -19,7 +19,7 @@ static Braze *rsBrazeInstance;
         self.config = config;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
-        self.useRecommendedEcommerceEvents = [[config objectForKey:@"useRecommendedEcommerceEvents"] boolValue] ? YES : NO;
+        self.useEcommerceRecommendedEvents = [[config objectForKey:@"useEcommerceRecommendedEvents"] boolValue] ? YES : NO;
 
         BOOL usePlatformSpecificAppIdentifierKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
         NSString *appIdentifierKey = @"";
@@ -269,7 +269,7 @@ static Braze *rsBrazeInstance;
     } else if([message.type isEqualToString:@"track"]) {
         // When enabled, recommended ecommerce events are handled before the legacy paths; other
         // events fall through unchanged.
-        if (self.useRecommendedEcommerceEvents) {
+        if (self.useEcommerceRecommendedEvents) {
             RudderBrazeEcommerceEvent *ecommerceEvent = [RudderBrazeEcommerceUtils resolveEcommerceEvent:message.event];
             if (ecommerceEvent != nil) {
                 NSDictionary *brazeProperties = [RudderBrazeEcommerceUtils buildEcommerceProperties:ecommerceEvent properties:message.properties];

--- a/Rudder-Braze/Classes/RudderBrazeIntegration.m
+++ b/Rudder-Braze/Classes/RudderBrazeIntegration.m
@@ -7,6 +7,7 @@
 #import "RudderBrazeIntegration.h"
 
 #import "RudderBrazeFactory.h"
+#import "RudderBrazeEcommerceUtils.h"
 @implementation RudderBrazeIntegration
 
 #pragma mark - Initialization
@@ -18,6 +19,9 @@ static Braze *rsBrazeInstance;
         self.config = config;
         self.client = client;
         self.supportDedup = [[config objectForKey:@"supportDedup"] boolValue] ? YES : NO;
+        // Recommended ecommerce events flag (default off; on = hard cutover). Mapping logic lives
+        // in RudderBrazeEcommerceUtils.
+        self.useRecommendedEcommerceEvents = [[config objectForKey:@"useRecommendedEcommerceEvents"] boolValue] ? YES : NO;
 
         BOOL usePlatformSpecificAppIdentifierKeys = [[config objectForKey:@"usePlatformSpecificApiKeys"] boolValue];
         NSString *appIdentifierKey = @"";
@@ -265,6 +269,19 @@ static Braze *rsBrazeInstance;
         }
         self.previousIdentifyElement = message;
     } else if([message.type isEqualToString:@"track"]) {
+        // When the flag is on, recommended ecommerce events take a hard cutover before the legacy
+        // Install Attributed / Order Completed paths. Events with no recommended-event counterpart
+        // (Product Clicked, Cart Viewed, Install Attributed, etc.) fall through and keep their
+        // existing behaviour.
+        if (self.useRecommendedEcommerceEvents) {
+            RudderBrazeEcommerceEvent *ecommerceEvent = [RudderBrazeEcommerceUtils resolveEcommerceEvent:message.event];
+            if (ecommerceEvent != nil) {
+                NSDictionary *brazeProperties = [RudderBrazeEcommerceUtils buildEcommerceProperties:ecommerceEvent properties:message.properties];
+                [rsBrazeInstance logCustomEvent:ecommerceEvent.brazeEvent withProperties:brazeProperties];
+                [RSLogger logInfo:@"Braze logCustomEvent: withProperties: for recommended ecommerce event"];
+                return;
+            }
+        }
         if ([message.event isEqualToString:@"Install Attributed"]) {
             if ([message.properties[@"campaign"] isKindOfClass:[NSDictionary class]]) {
                 NSDictionary *attributionDataDictionary = (NSDictionary *)message.properties[@"campaign"];


### PR DESCRIPTION
## Description

Adds support for Braze **recommended ecommerce events** (`ecommerce.*`) to the v1 iOS device-mode integration, behind the opt-in `useRecommendedEcommerceEvents` flag (default **off**, hard cutover when on). When the flag is on, RudderStack standard ecommerce `track` events are mapped to Braze recommended events via `logCustomEvent:withProperties:`; when off, existing behaviour (legacy `Order Completed -> logPurchase`, generic custom events) is unchanged.

Business logic and field mappings are a faithful port of the Android v1 and Kotlin device-mode implementations (Kotlin PR is the source of truth), so all three mobile device-mode integrations behave identically.

### Event mapping (RS -> Braze)
| RudderStack event | Braze recommended event |
|---|---|
| Product Viewed | `ecommerce.product_viewed` |
| Product Added | `ecommerce.cart_updated` (action `add`) |
| Product Removed | `ecommerce.cart_updated` (action `remove`) |
| Checkout Started | `ecommerce.checkout_started` |
| Order Completed | `ecommerce.order_placed` |
| Order Refunded | `ecommerce.order_refunded` |
| Order Cancelled | `ecommerce.order_cancelled` |

Event-name resolution is case-insensitive and runs before the legacy `Order Completed` path. Events with no recommended-event counterpart (Product Clicked, Cart Viewed, Install Attributed, etc.) fall through and keep their existing behaviour.

### Key decisions
- `logCustomEvent:withProperties:` for all 6 events (no native Braze SDK bump; nested `products[]`/`metadata` are supported on the current pins).
- `source` hardcoded to `"ios"` (no channel derivation).
- Send-anyway posture: a missing Braze-required field is logged via `RSLogger logWarn` but never drops the event.
- Unmapped keys are routed into `metadata` / `products[].metadata`, never left top-level.
- Mapping lives in a new stateless `RudderBrazeEcommerceUtils`; the `logCustomEvent` call stays in `RudderBrazeIntegration`.

### Verification
- Example app builds clean (`xcodebuild ... build` — **BUILD SUCCEEDED**) with the new files compiled into the framework.
- Mapping logic reviewed line-by-line against the Android `Utils.java` for parity.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Notes / follow-ups (intentionally not in this PR)
- Version bump (4.4.0 -> ~4.5.0), README/podspec/`package.json` — deferred to release prep (consistent with the Android slice).
- Unit tests — to be decided alongside the Android harness.
- End-to-end Braze acceptance verification + ~50 KB event-property size-limit check.

## Checklist
- [ ] Version upgraded (project, README, gradle, podspec etc) — deferred, see notes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code — see notes
- [ ] I have made corresponding changes to the documentation